### PR TITLE
feat(query): add Neo4j basic routing

### DIFF
--- a/unibridge-service/app/routers/admin.py
+++ b/unibridge-service/app/routers/admin.py
@@ -40,6 +40,11 @@ def _validate_connection_options(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="ClickHouse connections require both protocol and secure fields",
             )
+        if protocol not in {"http", "https"}:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="ClickHouse protocol must be http or https",
+            )
         expected_protocol = "https" if secure else "http"
         if protocol != expected_protocol:
             raise HTTPException(
@@ -54,6 +59,11 @@ def _validate_connection_options(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Neo4j connections require protocol field",
             )
+        if protocol not in {"bolt", "bolt+s", "bolt+ssc", "neo4j", "neo4j+s", "neo4j+ssc"}:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Neo4j protocol must be bolt, bolt+s, bolt+ssc, neo4j, neo4j+s, or neo4j+ssc",
+            )
         if secure is not None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -61,10 +71,15 @@ def _validate_connection_options(
             )
         return protocol, None
 
-    if protocol is not None or secure is not None:
+    if secure is not None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="protocol and secure are only valid for clickhouse or neo4j connections",
+            detail="secure is only valid for clickhouse connections",
+        )
+    if protocol is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="protocol is only valid for clickhouse or neo4j connections",
         )
     return None, None
 

--- a/unibridge-service/app/routers/admin.py
+++ b/unibridge-service/app/routers/admin.py
@@ -48,10 +48,23 @@ def _validate_connection_options(
             )
         return protocol, secure
 
+    if db_type == "neo4j":
+        if protocol is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Neo4j connections require protocol field",
+            )
+        if secure is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="secure is not valid for neo4j connections",
+            )
+        return protocol, None
+
     if protocol is not None or secure is not None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="protocol and secure are only valid for clickhouse connections",
+            detail="protocol and secure are only valid for clickhouse or neo4j connections",
         )
     return None, None
 

--- a/unibridge-service/app/routers/query.py
+++ b/unibridge-service/app/routers/query.py
@@ -178,7 +178,7 @@ async def execute(
             neo4j_driver = connection_manager.get_neo4j_driver(req.database)
             response = await execute_neo4j_query(
                 driver=neo4j_driver,
-                database=req.database,
+                database=connection_manager.get_database_name(req.database),
                 query=req.sql,
                 params=req.params,
                 limit=req.limit,

--- a/unibridge-service/app/routers/query.py
+++ b/unibridge-service/app/routers/query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -25,6 +26,27 @@ from app.services.table_access import check_table_access, extract_tables
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Query"])
+
+
+def _detect_neo4j_statement_type(sql: str) -> str:
+    normalized = re.sub(r"\s+", " ", sql.strip()).upper()
+    if re.search(r"\bDETACH\s+DELETE\b|\bDELETE\b", normalized):
+        return "delete"
+    if re.search(r"\bSET\b|\bREMOVE\b", normalized):
+        return "update"
+    if re.search(r"\bCREATE\b|\bMERGE\b", normalized):
+        return "insert"
+    if re.search(r"\bLOAD\s+CSV\b|\bCALL\b|\bDROP\b", normalized):
+        return "execute"
+    if re.match(r"^(MATCH\b.*\bRETURN\b|RETURN\b|WITH\b.*\bRETURN\b)", normalized):
+        return "select"
+    return "unknown"
+
+
+def _detect_statement_type(sql: str, db_type: str) -> str:
+    if db_type == "neo4j":
+        return _detect_neo4j_statement_type(sql)
+    return detect_statement_type(sql)
 
 
 @router.post("/query/execute", response_model=QueryResponse)
@@ -78,13 +100,7 @@ async def execute(
     perm = None
     if isinstance(user, ApiKeyUser):
         # API key users: only SELECT allowed
-        statement_type = detect_statement_type(req.sql)
-        if (
-            db_type == "neo4j"
-            and statement_type == "unknown"
-            and req.sql.lstrip().upper().startswith(("MATCH", "RETURN"))
-        ):
-            statement_type = "select"
+        statement_type = _detect_statement_type(req.sql, db_type)
         if statement_type != "select":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -92,13 +108,7 @@ async def execute(
             )
     else:
         # JWT user: role-based per-DB permissions
-        statement_type = detect_statement_type(req.sql)
-        if (
-            db_type == "neo4j"
-            and statement_type == "unknown"
-            and req.sql.lstrip().upper().startswith(("MATCH", "RETURN"))
-        ):
-            statement_type = "select"
+        statement_type = _detect_statement_type(req.sql, db_type)
         user_perms = await get_role_permissions(db, user.role)
         if "query.databases.write" not in user_perms:
             result = await db.execute(

--- a/unibridge-service/app/routers/query.py
+++ b/unibridge-service/app/routers/query.py
@@ -96,7 +96,10 @@ def _detect_neo4j_statement_type(sql: str) -> str:
         or _contains_neo4j_clause(normalized, "DROP")
     ):
         return "execute"
-    if re.match(r"^(MATCH\b.*\bRETURN\b|RETURN\b|WITH\b.*\bRETURN\b)", normalized):
+    if re.match(
+        r"^(OPTIONAL\s+MATCH\b.*\bRETURN\b|MATCH\b.*\bRETURN\b|RETURN\b|WITH\b.*\bRETURN\b|UNWIND\b.*\bRETURN\b)",
+        normalized,
+    ):
         return "select"
     return "unknown"
 
@@ -153,12 +156,17 @@ async def execute(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Database '{req.database}' is not registered or not connected",
         )
+    statement_type = _detect_statement_type(req.sql, db_type)
+    if db_type == "neo4j" and statement_type != "select":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Neo4j queries are read-only",
+        )
 
     # 2. Check per-database permissions
     perm = None
     if isinstance(user, ApiKeyUser):
         # API key users: only SELECT allowed
-        statement_type = _detect_statement_type(req.sql, db_type)
         if statement_type != "select":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -166,7 +174,6 @@ async def execute(
             )
     else:
         # JWT user: role-based per-DB permissions
-        statement_type = _detect_statement_type(req.sql, db_type)
         user_perms = await get_role_permissions(db, user.role)
         if "query.databases.write" not in user_perms:
             result = await db.execute(

--- a/unibridge-service/app/routers/query.py
+++ b/unibridge-service/app/routers/query.py
@@ -17,7 +17,7 @@ from app.schemas import DBConnectionResponse, HealthResponse, QueryRequest, Quer
 from app.middleware.rate_limiter import rate_limiter
 from app.services.audit import log_query
 from app.services.connection_manager import connection_manager
-from app.services.query_executor import check_permission, detect_statement_type, execute_clickhouse_query, execute_query
+from app.services.query_executor import check_permission, detect_statement_type, execute_clickhouse_query, execute_neo4j_query, execute_query
 from app.services.settings_manager import settings_manager
 from app.services.sql_validator import validate_sql
 from app.services.table_access import check_table_access, extract_tables
@@ -79,6 +79,12 @@ async def execute(
     if isinstance(user, ApiKeyUser):
         # API key users: only SELECT allowed
         statement_type = detect_statement_type(req.sql)
+        if (
+            db_type == "neo4j"
+            and statement_type == "unknown"
+            and req.sql.lstrip().upper().startswith(("MATCH", "RETURN"))
+        ):
+            statement_type = "select"
         if statement_type != "select":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -87,6 +93,12 @@ async def execute(
     else:
         # JWT user: role-based per-DB permissions
         statement_type = detect_statement_type(req.sql)
+        if (
+            db_type == "neo4j"
+            and statement_type == "unknown"
+            and req.sql.lstrip().upper().startswith(("MATCH", "RETURN"))
+        ):
+            statement_type = "select"
         user_perms = await get_role_permissions(db, user.role)
         if "query.databases.write" not in user_perms:
             result = await db.execute(
@@ -127,7 +139,7 @@ async def execute(
         if "query.databases.write" not in user_perms_for_tables and perm is not None:
             allowed_tables_raw = perm.allowed_tables
             allowed_tables = json.loads(allowed_tables_raw) if allowed_tables_raw else None
-            if allowed_tables is not None:
+            if allowed_tables is not None and db_type != "neo4j":
                 referenced = extract_tables(req.sql, db_type=db_type)
                 table_error = check_table_access(referenced, allowed_tables)
                 if table_error:
@@ -151,6 +163,16 @@ async def execute(
             response = await execute_clickhouse_query(
                 client=ch_client, sql=req.sql, params=req.params,
                 limit=req.limit, timeout=req.timeout,
+            )
+        elif db_type == "neo4j":
+            neo4j_driver = connection_manager.get_neo4j_driver(req.database)
+            response = await execute_neo4j_query(
+                driver=neo4j_driver,
+                database=req.database,
+                query=req.sql,
+                params=req.params,
+                limit=req.limit,
+                timeout=req.timeout,
             )
         else:
             engine = connection_manager.get_engine(req.database)

--- a/unibridge-service/app/routers/query.py
+++ b/unibridge-service/app/routers/query.py
@@ -28,15 +28,73 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Query"])
 
 
+def _strip_neo4j_literals_and_comments(sql: str) -> str:
+    result: list[str] = []
+    i = 0
+    length = len(sql)
+    while i < length:
+        char = sql[i]
+        if char == "/" and i + 1 < length and sql[i + 1] == "/":
+            i = sql.find("\n", i)
+            if i == -1:
+                break
+            result.append(" ")
+            continue
+        if char == "/" and i + 1 < length and sql[i + 1] == "*":
+            end = sql.find("*/", i + 2)
+            if end == -1:
+                break
+            result.append(" ")
+            i = end + 2
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            i += 1
+            while i < length:
+                if sql[i] == "\\":
+                    i += 2
+                    continue
+                if sql[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            result.append("''")
+            continue
+        result.append(char)
+        i += 1
+    return "".join(result)
+
+
+def _contains_neo4j_clause(sql: str, pattern: str) -> bool:
+    return re.search(rf"(?<!\S){pattern}\b", sql) is not None
+
+
 def _detect_neo4j_statement_type(sql: str) -> str:
-    normalized = re.sub(r"\s+", " ", sql.strip()).upper()
-    if re.search(r"\bDETACH\s+DELETE\b|\bDELETE\b", normalized):
+    normalized = re.sub(
+        r"\s+",
+        " ",
+        _strip_neo4j_literals_and_comments(sql).strip(),
+    ).upper()
+    if _contains_neo4j_clause(
+        normalized,
+        r"DETACH\s+DELETE",
+    ) or _contains_neo4j_clause(normalized, "DELETE"):
         return "delete"
-    if re.search(r"\bSET\b|\bREMOVE\b", normalized):
+    if _contains_neo4j_clause(normalized, "SET") or _contains_neo4j_clause(
+        normalized,
+        "REMOVE",
+    ):
         return "update"
-    if re.search(r"\bCREATE\b|\bMERGE\b", normalized):
+    if _contains_neo4j_clause(normalized, "CREATE") or _contains_neo4j_clause(
+        normalized,
+        "MERGE",
+    ):
         return "insert"
-    if re.search(r"\bLOAD\s+CSV\b|\bCALL\b|\bDROP\b", normalized):
+    if (
+        _contains_neo4j_clause(normalized, r"LOAD\s+CSV")
+        or _contains_neo4j_clause(normalized, "CALL")
+        or _contains_neo4j_clause(normalized, "DROP")
+    ):
         return "execute"
     if re.match(r"^(MATCH\b.*\bRETURN\b|RETURN\b|WITH\b.*\bRETURN\b)", normalized):
         return "select"

--- a/unibridge-service/app/schemas.py
+++ b/unibridge-service/app/schemas.py
@@ -29,13 +29,13 @@ class QueryResponse(BaseModel):
 
 class DBConnectionCreate(BaseModel):
     alias: str = Field(..., min_length=1, max_length=100)
-    db_type: str = Field(..., pattern=r"^(postgres|mssql|clickhouse)$")
+    db_type: str = Field(..., pattern=r"^(postgres|mssql|clickhouse|neo4j)$")
     host: str = Field(..., min_length=1)
     port: int = Field(..., ge=1, le=65535)
     database: str = Field(..., min_length=1)
     username: str = Field(..., min_length=1)
     password: str = Field(..., min_length=1)
-    protocol: str | None = Field(None, pattern=r"^(http|https)$")
+    protocol: str | None = Field(None, pattern=r"^(http|https|bolt|bolt\+s|bolt\+ssc|neo4j|neo4j\+s|neo4j\+ssc)$")
     secure: bool | None = None
     pool_size: int | None = Field(5, ge=1, le=50)
     max_overflow: int | None = Field(3, ge=0, le=50)
@@ -48,7 +48,7 @@ class DBConnectionUpdate(BaseModel):
     database: str | None = None
     username: str | None = None
     password: str | None = None
-    protocol: str | None = Field(None, pattern=r"^(http|https)$")
+    protocol: str | None = Field(None, pattern=r"^(http|https|bolt|bolt\+s|bolt\+ssc|neo4j|neo4j\+s|neo4j\+ssc)$")
     secure: bool | None = None
     pool_size: int | None = Field(None, ge=1, le=50)
     max_overflow: int | None = Field(None, ge=0, le=50)

--- a/unibridge-service/app/services/connection_manager.py
+++ b/unibridge-service/app/services/connection_manager.py
@@ -82,6 +82,7 @@ class ConnectionManager:
     _instance: ConnectionManager | None = None
     _engines: dict[str, AsyncEngine]
     _ch_clients: dict[str, Any]
+    _neo4j_drivers: dict[str, Any]
     _db_types: dict[str, str]
 
     def __new__(cls) -> ConnectionManager:
@@ -89,11 +90,24 @@ class ConnectionManager:
             cls._instance = super().__new__(cls)
             cls._instance._engines = {}
             cls._instance._ch_clients = {}
+            cls._instance._neo4j_drivers = {}
             cls._instance._db_types = {}
         return cls._instance
 
+    def _ensure_registries(self) -> None:
+        """Initialize registries for test instances that bypass __new__."""
+        if not hasattr(self, "_engines"):
+            self._engines = {}
+        if not hasattr(self, "_ch_clients"):
+            self._ch_clients = {}
+        if not hasattr(self, "_neo4j_drivers"):
+            self._neo4j_drivers = {}
+        if not hasattr(self, "_db_types"):
+            self._db_types = {}
+
     async def initialize(self, connections: list[DBConnection]) -> None:
         """Create engines/clients for all saved connections on startup."""
+        self._ensure_registries()
         validate_encryption_key()
         for conn in connections:
             try:
@@ -103,7 +117,12 @@ class ConnectionManager:
 
     async def add_connection(self, conn: DBConnection) -> None:
         """Create an engine/client and register it under the given alias."""
-        if conn.alias in self._engines or conn.alias in self._ch_clients:
+        self._ensure_registries()
+        if (
+            conn.alias in self._engines
+            or conn.alias in self._ch_clients
+            or conn.alias in self._neo4j_drivers
+        ):
             await self.remove_connection(conn.alias)
 
         password = decrypt_password(conn.password_encrypted)
@@ -124,6 +143,17 @@ class ConnectionManager:
                 send_receive_timeout=query_timeout,
             )
             self._ch_clients[conn.alias] = client
+        elif conn.db_type == "neo4j":
+            from neo4j import GraphDatabase
+
+            protocol = conn.protocol or "bolt"
+            uri = f"{protocol}://{conn.host}:{conn.port}"
+            driver = await asyncio.to_thread(
+                GraphDatabase.driver,
+                uri,
+                auth=(conn.username, password),
+            )
+            self._neo4j_drivers[conn.alias] = driver
         else:
             url = _build_url(conn, password)
             engine_kwargs: dict[str, Any] = {"echo": False}
@@ -139,8 +169,10 @@ class ConnectionManager:
 
     async def remove_connection(self, alias: str) -> None:
         """Dispose of the connection for the given alias and remove it."""
+        self._ensure_registries()
         engine = self._engines.pop(alias, None)
         client = self._ch_clients.pop(alias, None)
+        neo4j_driver = self._neo4j_drivers.pop(alias, None)
         self._db_types.pop(alias, None)
         if engine is not None:
             await engine.dispose()
@@ -148,6 +180,9 @@ class ConnectionManager:
         if client is not None:
             await asyncio.to_thread(client.close)
             logger.info("ClickHouse client closed for alias '%s'", alias)
+        if neo4j_driver is not None:
+            await asyncio.to_thread(neo4j_driver.close)
+            logger.info("Neo4j driver closed for alias '%s'", alias)
 
     def get_engine(self, alias: str) -> AsyncEngine:
         """Return the SQLAlchemy engine for a given alias, or raise KeyError."""
@@ -163,13 +198,21 @@ class ConnectionManager:
         except KeyError:
             raise KeyError(f"No ClickHouse client registered for alias '{alias}'")
 
+    def get_neo4j_driver(self, alias: str) -> Any:
+        """Return the Neo4j driver for a given alias, or raise KeyError."""
+        try:
+            return self._neo4j_drivers[alias]
+        except KeyError:
+            raise KeyError(f"No Neo4j driver registered for alias '{alias}'")
+
     def get_db_type(self, alias: str) -> str:
         """Return the database type for a given alias."""
         return self._db_types.get(alias, "unknown")
 
     def has_connection(self, alias: str) -> bool:
         """Return True if the alias has a registered connection."""
-        return alias in self._engines or alias in self._ch_clients
+        self._ensure_registries()
+        return alias in self._engines or alias in self._ch_clients or alias in self._neo4j_drivers
 
     async def test_connection(self, alias: str) -> tuple[bool, str]:
         """Test connectivity. Returns (ok, message)."""
@@ -181,6 +224,10 @@ class ConnectionManager:
                 if ok:
                     return True, "Connection successful"
                 return False, "Ping failed"
+            elif db_type == "neo4j":
+                driver = self.get_neo4j_driver(alias)
+                await asyncio.to_thread(driver.verify_connectivity)
+                return True, "Connection successful"
             else:
                 engine = self.get_engine(alias)
                 async with engine.connect() as conn:
@@ -192,11 +239,18 @@ class ConnectionManager:
 
     def get_status(self, alias: str) -> dict[str, Any]:
         """Return status info for the given alias."""
+        self._ensure_registries()
         if alias in self._ch_clients:
             return {
                 "alias": alias,
                 "status": "registered",
                 "driver": "clickhouse-connect",
+            }
+        if alias in self._neo4j_drivers:
+            return {
+                "alias": alias,
+                "status": "registered",
+                "driver": "neo4j",
             }
 
         engine = self._engines.get(alias)
@@ -215,9 +269,10 @@ class ConnectionManager:
 
     def update_pool_metrics(self, alias: str | None = None) -> None:
         """Publish current checked-out pool counts for registered DB aliases."""
+        self._ensure_registries()
         aliases = [alias] if alias is not None else self.list_aliases()
         for current_alias in aliases:
-            if current_alias in self._ch_clients:
+            if current_alias in self._ch_clients or current_alias in self._neo4j_drivers:
                 continue
 
             engine = self._engines.get(current_alias)
@@ -233,11 +288,16 @@ class ConnectionManager:
 
     def list_aliases(self) -> list[str]:
         """Return all registered aliases."""
-        return list(self._engines.keys()) + list(self._ch_clients.keys())
+        self._ensure_registries()
+        return (
+            list(self._engines.keys())
+            + list(self._ch_clients.keys())
+            + list(self._neo4j_drivers.keys())
+        )
 
     async def dispose_all(self) -> None:
         """Dispose of all connections. Called on application shutdown."""
-        for alias in list(self._engines.keys()) + list(self._ch_clients.keys()):
+        for alias in self.list_aliases():
             await self.remove_connection(alias)
 
 

--- a/unibridge-service/app/services/connection_manager.py
+++ b/unibridge-service/app/services/connection_manager.py
@@ -84,6 +84,7 @@ class ConnectionManager:
     _ch_clients: dict[str, Any]
     _neo4j_drivers: dict[str, Any]
     _db_types: dict[str, str]
+    _databases: dict[str, str]
 
     def __new__(cls) -> ConnectionManager:
         if cls._instance is None:
@@ -92,6 +93,7 @@ class ConnectionManager:
             cls._instance._ch_clients = {}
             cls._instance._neo4j_drivers = {}
             cls._instance._db_types = {}
+            cls._instance._databases = {}
         return cls._instance
 
     def _ensure_registries(self) -> None:
@@ -104,6 +106,8 @@ class ConnectionManager:
             self._neo4j_drivers = {}
         if not hasattr(self, "_db_types"):
             self._db_types = {}
+        if not hasattr(self, "_databases"):
+            self._databases = {}
 
     async def initialize(self, connections: list[DBConnection]) -> None:
         """Create engines/clients for all saved connections on startup."""
@@ -164,6 +168,7 @@ class ConnectionManager:
             self._engines[conn.alias] = engine
 
         self._db_types[conn.alias] = conn.db_type
+        self._databases[conn.alias] = conn.database
         self.update_pool_metrics(conn.alias)
         logger.info("Connection created for alias '%s' (%s)", conn.alias, conn.db_type)
 
@@ -174,6 +179,7 @@ class ConnectionManager:
         client = self._ch_clients.pop(alias, None)
         neo4j_driver = self._neo4j_drivers.pop(alias, None)
         self._db_types.pop(alias, None)
+        self._databases.pop(alias, None)
         if engine is not None:
             await engine.dispose()
             logger.info("Engine disposed for alias '%s'", alias)
@@ -208,6 +214,13 @@ class ConnectionManager:
     def get_db_type(self, alias: str) -> str:
         """Return the database type for a given alias."""
         return self._db_types.get(alias, "unknown")
+
+    def get_database_name(self, alias: str) -> str:
+        """Return the configured database name for a given alias, or raise KeyError."""
+        try:
+            return self._databases[alias]
+        except KeyError:
+            raise KeyError(f"No database registered for alias '{alias}'")
 
     def has_connection(self, alias: str) -> bool:
         """Return True if the alias has a registered connection."""

--- a/unibridge-service/app/services/query_executor.py
+++ b/unibridge-service/app/services/query_executor.py
@@ -18,6 +18,7 @@ __all__ = [
     "check_permission",
     "detect_statement_type",
     "execute_clickhouse_query",
+    "execute_neo4j_query",
     "execute_query",
 ]
 
@@ -390,3 +391,60 @@ async def execute_clickhouse_query(
     except asyncio.TimeoutError:
         logger.warning("Query timed out after %ds", effective_timeout)
         raise
+
+
+# ── Neo4j execution path ─────────────────────────────────────────────────────
+
+
+def _execute_neo4j_sync(
+    driver: Any,
+    database: str,
+    query: str,
+    params: dict[str, Any] | None,
+    limit: int,
+) -> QueryResponse:
+    """Core execution logic for Neo4j via the official driver."""
+    start = time.monotonic()
+    with driver.session(database=database) as session:
+        result = session.run(query, **(params or {}))
+        columns = list(result.keys())
+        rows: list[list[Any]] = []
+        truncated = False
+        for index, record in enumerate(result):
+            if index >= limit:
+                truncated = True
+                break
+            rows.append(list(record.values()))
+
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    return QueryResponse(
+        columns=columns,
+        rows=rows,
+        row_count=len(rows),
+        truncated=truncated,
+        elapsed_ms=elapsed_ms,
+    )
+
+
+async def execute_neo4j_query(
+    driver: Any,
+    database: str,
+    query: str,
+    params: dict[str, Any] | None = None,
+    limit: int | None = None,
+    timeout: int | None = None,
+) -> QueryResponse:
+    """Execute a Neo4j Cypher query with timeout and row limit."""
+    effective_limit = limit or settings.DEFAULT_ROW_LIMIT
+    effective_timeout = timeout or settings.DEFAULT_QUERY_TIMEOUT
+    return await asyncio.wait_for(
+        asyncio.to_thread(
+            _execute_neo4j_sync,
+            driver,
+            database,
+            query,
+            params,
+            effective_limit,
+        ),
+        timeout=effective_timeout,
+    )

--- a/unibridge-service/app/services/query_executor.py
+++ b/unibridge-service/app/services/query_executor.py
@@ -415,7 +415,10 @@ async def execute_clickhouse_query(
 
 
 def _neo4j_entity_id(entity: Any) -> Any:
-    return getattr(entity, "element_id", None) or getattr(entity, "id", None)
+    element_id = getattr(entity, "element_id", None)
+    if element_id is not None:
+        return element_id
+    return getattr(entity, "id", None)
 
 
 def _convert_neo4j_mapping(mapping: Any) -> dict[str, Any]:

--- a/unibridge-service/app/services/query_executor.py
+++ b/unibridge-service/app/services/query_executor.py
@@ -8,6 +8,24 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+try:  # pragma: no cover - exercised when neo4j is installed
+    from neo4j import Query as Neo4jQuery
+    from neo4j.graph import Node as Neo4jNode
+    from neo4j.graph import Path as Neo4jPath
+    from neo4j.graph import Relationship as Neo4jRelationship
+except ImportError:  # pragma: no cover - test environment may omit neo4j
+    class Neo4jQuery:
+        def __init__(self, text: str, timeout: int | float | None = None) -> None:
+            self.text = text
+            self.timeout = timeout
+
+        def __str__(self) -> str:
+            return self.text
+
+    Neo4jNode = ()
+    Neo4jPath = ()
+    Neo4jRelationship = ()
+
 from app.config import settings
 from app.schemas import QueryResponse
 from app.services.sql_analysis import statement_type
@@ -396,17 +414,83 @@ async def execute_clickhouse_query(
 # ── Neo4j execution path ─────────────────────────────────────────────────────
 
 
+def _neo4j_entity_id(entity: Any) -> Any:
+    return getattr(entity, "element_id", None) or getattr(entity, "id", None)
+
+
+def _convert_neo4j_mapping(mapping: Any) -> dict[str, Any]:
+    return {key: _convert_neo4j_value(value) for key, value in dict(mapping).items()}
+
+
+def _convert_neo4j_value(value: Any) -> Any:
+    """Convert Neo4j values to JSON-serializable Python objects."""
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+
+    if isinstance(value, Neo4jNode):
+        return {
+            "id": _neo4j_entity_id(value),
+            "labels": sorted(value.labels),
+            "properties": _convert_neo4j_mapping(value),
+        }
+
+    if isinstance(value, Neo4jRelationship):
+        return {
+            "id": _neo4j_entity_id(value),
+            "type": value.type,
+            "start_node_id": _neo4j_entity_id(value.start_node),
+            "end_node_id": _neo4j_entity_id(value.end_node),
+            "properties": _convert_neo4j_mapping(value),
+        }
+
+    if isinstance(value, Neo4jPath):
+        return {
+            "nodes": [_convert_neo4j_value(node) for node in value.nodes],
+            "relationships": [
+                _convert_neo4j_value(relationship)
+                for relationship in value.relationships
+            ],
+        }
+
+    if isinstance(value, dict):
+        return {
+            key: _convert_neo4j_value(nested_value)
+            for key, nested_value in value.items()
+        }
+
+    if isinstance(value, list | tuple):
+        return [_convert_neo4j_value(item) for item in value]
+
+    if isinstance(value, set):
+        return sorted(
+            (_convert_neo4j_value(item) for item in value),
+            key=str,
+        )
+
+    iso_format = getattr(value, "iso_format", None)
+    if callable(iso_format):
+        return iso_format()
+
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+
+    return str(value)
+
+
 def _execute_neo4j_sync(
     driver: Any,
     database: str,
     query: str,
     params: dict[str, Any] | None,
     limit: int,
+    timeout: int | float,
 ) -> QueryResponse:
     """Core execution logic for Neo4j via the official driver."""
     start = time.monotonic()
+    cypher = Neo4jQuery(query, timeout=timeout)
     with driver.session(database=database) as session:
-        result = session.run(query, **(params or {}))
+        result = session.run(cypher, parameters=params or {})
         columns = list(result.keys())
         rows: list[list[Any]] = []
         truncated = False
@@ -414,7 +498,7 @@ def _execute_neo4j_sync(
             if index >= limit:
                 truncated = True
                 break
-            rows.append(list(record.values()))
+            rows.append([_convert_neo4j_value(value) for value in record.values()])
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
     return QueryResponse(
@@ -437,14 +521,19 @@ async def execute_neo4j_query(
     """Execute a Neo4j Cypher query with timeout and row limit."""
     effective_limit = limit or settings.DEFAULT_ROW_LIMIT
     effective_timeout = timeout or settings.DEFAULT_QUERY_TIMEOUT
-    return await asyncio.wait_for(
-        asyncio.to_thread(
-            _execute_neo4j_sync,
-            driver,
-            database,
-            query,
-            params,
-            effective_limit,
-        ),
-        timeout=effective_timeout,
-    )
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(
+                _execute_neo4j_sync,
+                driver,
+                database,
+                query,
+                params,
+                effective_limit,
+                effective_timeout,
+            ),
+            timeout=effective_timeout,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("Query timed out after %ds", effective_timeout)
+        raise

--- a/unibridge-service/requirements.txt
+++ b/unibridge-service/requirements.txt
@@ -12,5 +12,6 @@ cryptography==47.0.0
 httpx==0.28.1
 prometheus-fastapi-instrumentator>=7.0,<8
 clickhouse-connect==0.15.1
+neo4j==5.28.2
 sqlglot==30.6.0
 boto3>=1.35.0,<2

--- a/unibridge-service/tests/test_admin.py
+++ b/unibridge-service/tests/test_admin.py
@@ -226,6 +226,28 @@ class TestCreateConnection:
         assert "same transport" in resp.json()["detail"].lower()
 
     @pytest.mark.asyncio
+    async def test_create_clickhouse_with_neo4j_protocol_returns_400(self, client, admin_token):
+        with _cm_patch():
+            resp = await client.post(
+                "/admin/query/databases",
+                json={**CLICKHOUSE_PAYLOAD, "protocol": "bolt", "secure": False},
+                headers=auth_header(admin_token),
+            )
+        assert resp.status_code == 400
+        assert "clickhouse protocol" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_create_neo4j_with_clickhouse_protocol_returns_400(self, client, admin_token):
+        with _cm_patch():
+            resp = await client.post(
+                "/admin/query/databases",
+                json={**NEO4J_PAYLOAD, "protocol": "http"},
+                headers=auth_header(admin_token),
+            )
+        assert resp.status_code == 400
+        assert "neo4j protocol" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
     async def test_create_clickhouse_missing_protocol_or_secure_returns_400(
         self, client, admin_token
     ):

--- a/unibridge-service/tests/test_admin.py
+++ b/unibridge-service/tests/test_admin.py
@@ -33,6 +33,17 @@ CLICKHOUSE_PAYLOAD = {
     "secure": False,
 }
 
+NEO4J_PAYLOAD = {
+    "alias": "graph",
+    "db_type": "neo4j",
+    "host": "neo4j.internal",
+    "port": 7687,
+    "database": "neo4j",
+    "username": "neo4j",
+    "password": "secret",
+    "protocol": "bolt",
+}
+
 
 def _make_db_payload(**overrides) -> dict:
     """Return a fresh DB connection payload with optional overrides."""
@@ -153,6 +164,42 @@ class TestCreateConnection:
         assert data["db_type"] == "clickhouse"
         assert data["protocol"] == "http"
         assert data["secure"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_neo4j_connection_success(self, client, admin_token):
+        with _cm_patch():
+            resp = await client.post(
+                "/admin/query/databases",
+                json=NEO4J_PAYLOAD,
+                headers=auth_header(admin_token),
+            )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["db_type"] == "neo4j"
+        assert data["protocol"] == "bolt"
+        assert data["secure"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_neo4j_missing_protocol_returns_400(self, client, admin_token):
+        with _cm_patch():
+            resp = await client.post(
+                "/admin/query/databases",
+                json={key: value for key, value in NEO4J_PAYLOAD.items() if key != "protocol"},
+                headers=auth_header(admin_token),
+            )
+        assert resp.status_code == 400
+        assert "require protocol" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_create_neo4j_with_secure_returns_400(self, client, admin_token):
+        with _cm_patch():
+            resp = await client.post(
+                "/admin/query/databases",
+                json={**NEO4J_PAYLOAD, "secure": True},
+                headers=auth_header(admin_token),
+            )
+        assert resp.status_code == 400
+        assert "secure" in resp.json()["detail"].lower()
 
     @pytest.mark.asyncio
     async def test_create_postgres_with_clickhouse_fields_returns_400(self, client, admin_token):

--- a/unibridge-service/tests/test_connection_manager_neo4j.py
+++ b/unibridge-service/tests/test_connection_manager_neo4j.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models import DBConnection
+from app.services.connection_manager import ConnectionManager, encrypt_password
+
+
+@pytest.fixture
+def fake_neo4j(monkeypatch):
+    """Install a fake neo4j module that records driver creation."""
+    module = types.ModuleType("neo4j")
+    driver = MagicMock()
+    graph_database = MagicMock()
+    graph_database.driver.return_value = driver
+    module.GraphDatabase = graph_database
+    monkeypatch.setitem(sys.modules, "neo4j", module)
+    return graph_database, driver
+
+
+@pytest.fixture
+def manager():
+    """Clear singleton registries so each test is isolated."""
+    mgr = ConnectionManager()
+    mgr._engines.clear()
+    mgr._ch_clients.clear()
+    mgr._neo4j_drivers.clear()
+    mgr._db_types.clear()
+    return mgr
+
+
+def _make_neo4j_conn(**overrides) -> DBConnection:
+    defaults = {
+        "alias": "graph",
+        "db_type": "neo4j",
+        "host": "neo4j.internal",
+        "port": 7687,
+        "database": "neo4j",
+        "username": "neo4j",
+        "password_encrypted": encrypt_password("secret"),
+        "protocol": "bolt",
+    }
+    defaults.update(overrides)
+    return DBConnection(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_add_connection_creates_neo4j_driver_and_registers_alias(manager, fake_neo4j):
+    graph_database, driver = fake_neo4j
+
+    await manager.add_connection(_make_neo4j_conn())
+
+    graph_database.driver.assert_called_once_with(
+        "bolt://neo4j.internal:7687",
+        auth=("neo4j", "secret"),
+    )
+    assert manager.get_neo4j_driver("graph") is driver
+    assert manager.get_db_type("graph") == "neo4j"
+
+
+@pytest.mark.asyncio
+async def test_remove_connection_closes_neo4j_driver_and_removes_alias(manager, fake_neo4j):
+    _, driver = fake_neo4j
+    await manager.add_connection(_make_neo4j_conn())
+
+    await manager.remove_connection("graph")
+
+    driver.close.assert_called_once_with()
+    assert manager.has_connection("graph") is False
+    assert manager.get_db_type("graph") == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_verifies_neo4j_connectivity(manager, fake_neo4j):
+    _, driver = fake_neo4j
+    await manager.add_connection(_make_neo4j_conn())
+
+    result = await manager.test_connection("graph")
+
+    driver.verify_connectivity.assert_called_once_with()
+    assert result == (True, "Connection successful")
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_neo4j_registered_status(manager, fake_neo4j):
+    await manager.add_connection(_make_neo4j_conn())
+
+    assert manager.get_status("graph") == {
+        "alias": "graph",
+        "status": "registered",
+        "driver": "neo4j",
+    }

--- a/unibridge-service/tests/test_connection_manager_neo4j.py
+++ b/unibridge-service/tests/test_connection_manager_neo4j.py
@@ -30,6 +30,7 @@ def manager():
     mgr._ch_clients.clear()
     mgr._neo4j_drivers.clear()
     mgr._db_types.clear()
+    mgr._databases.clear()
     return mgr
 
 
@@ -60,6 +61,7 @@ async def test_add_connection_creates_neo4j_driver_and_registers_alias(manager, 
     )
     assert manager.get_neo4j_driver("graph") is driver
     assert manager.get_db_type("graph") == "neo4j"
+    assert manager.get_database_name("graph") == "neo4j"
 
 
 @pytest.mark.asyncio
@@ -72,6 +74,8 @@ async def test_remove_connection_closes_neo4j_driver_and_removes_alias(manager, 
     driver.close.assert_called_once_with()
     assert manager.has_connection("graph") is False
     assert manager.get_db_type("graph") == "unknown"
+    with pytest.raises(KeyError, match="No database registered for alias 'graph'"):
+        manager.get_database_name("graph")
 
 
 @pytest.mark.asyncio

--- a/unibridge-service/tests/test_neo4j_query_executor.py
+++ b/unibridge-service/tests/test_neo4j_query_executor.py
@@ -2,7 +2,8 @@ import time
 
 import pytest
 
-from app.services.query_executor import execute_neo4j_query
+from app.services import query_executor
+from app.services.query_executor import _convert_neo4j_value, execute_neo4j_query
 
 
 class FakeRecord:
@@ -38,9 +39,9 @@ class FakeSession:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def run(self, query, **params):
+    def run(self, query, *, parameters):
         self.query = query
-        self.params = params
+        self.params = parameters
         if self.delay:
             time.sleep(self.delay)
         return self.result
@@ -82,7 +83,8 @@ async def test_execute_neo4j_query_limits_rows_and_returns_metadata():
     assert response.row_count == 2
     assert response.truncated is True
     assert response.elapsed_ms >= 0
-    assert session.query == "MATCH (n) RETURN n.name AS name, n.age AS age"
+    assert str(session.query) == "MATCH (n) RETURN n.name AS name, n.age AS age"
+    assert getattr(session.query, "timeout", None) == 30
     assert session.params == {"active": True}
     assert driver.database == "neo4j"
 
@@ -95,6 +97,92 @@ async def test_execute_neo4j_query_uses_empty_params_when_params_is_none():
     await execute_neo4j_query(driver, "neo4j", "MATCH (n) RETURN n", params=None, limit=1)
 
     assert session.params == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_neo4j_query_passes_conflicting_param_names_as_parameters_dict():
+    session = FakeSession(FakeResult(["n"], [FakeRecord(["node"])]))
+    driver = FakeDriver(session)
+    params = {"query": "x", "parameters": "y"}
+
+    await execute_neo4j_query(driver, "neo4j", "MATCH (n) RETURN n", params=params, limit=1)
+
+    assert session.params == params
+
+
+@pytest.mark.asyncio
+async def test_execute_neo4j_query_serializes_nested_values_and_falls_back_to_string():
+    class CustomObject:
+        def __str__(self):
+            return "custom-value"
+
+    session = FakeSession(
+        FakeResult(
+            ["value"],
+            [
+                FakeRecord(
+                    [
+                        {
+                            "items": [CustomObject(), {"nested": (CustomObject(),)}],
+                            "unique": {"b", "a"},
+                        }
+                    ]
+                )
+            ],
+        )
+    )
+    driver = FakeDriver(session)
+
+    response = await execute_neo4j_query(driver, "neo4j", "MATCH (n) RETURN n", limit=1)
+
+    assert response.rows == [
+        [
+            {
+                "items": ["custom-value", {"nested": ["custom-value"]}],
+                "unique": ["a", "b"],
+            }
+        ]
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_neo4j_query_uses_configured_query_timeout(monkeypatch):
+    class FakeQuery:
+        def __init__(self, text, timeout=None):
+            self.text = text
+            self.timeout = timeout
+
+        def __str__(self):
+            return self.text
+
+    monkeypatch.setattr(query_executor, "Neo4jQuery", FakeQuery)
+    session = FakeSession(FakeResult(["n"], [FakeRecord(["node"])]))
+    driver = FakeDriver(session)
+
+    await execute_neo4j_query(
+        driver,
+        "neo4j",
+        "MATCH (n) RETURN n",
+        limit=1,
+        timeout=7,
+    )
+
+    assert isinstance(session.query, FakeQuery)
+    assert str(session.query) == "MATCH (n) RETURN n"
+    assert session.query.timeout == 7
+
+
+def test_convert_neo4j_value_uses_iso_format_and_string_fallback():
+    class IsoFormatOnly:
+        def iso_format(self):
+            return "2026-05-02T00:00:00"
+
+    class CustomObject:
+        def __str__(self):
+            return "custom-value"
+
+    assert _convert_neo4j_value(IsoFormatOnly()) == "2026-05-02T00:00:00"
+    assert _convert_neo4j_value(CustomObject()) == "custom-value"
 
 
 @pytest.mark.asyncio

--- a/unibridge-service/tests/test_neo4j_query_executor.py
+++ b/unibridge-service/tests/test_neo4j_query_executor.py
@@ -1,0 +1,112 @@
+import time
+
+import pytest
+
+from app.services.query_executor import execute_neo4j_query
+
+
+class FakeRecord:
+    def __init__(self, values):
+        self._values = values
+
+    def values(self):
+        return self._values
+
+
+class FakeResult:
+    def __init__(self, keys, records):
+        self._keys = keys
+        self._records = records
+
+    def keys(self):
+        return self._keys
+
+    def __iter__(self):
+        return iter(self._records)
+
+
+class FakeSession:
+    def __init__(self, result=None, delay=0):
+        self.result = result or FakeResult([], [])
+        self.delay = delay
+        self.query = None
+        self.params = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def run(self, query, **params):
+        self.query = query
+        self.params = params
+        if self.delay:
+            time.sleep(self.delay)
+        return self.result
+
+
+class FakeDriver:
+    def __init__(self, session):
+        self._session = session
+        self.database = None
+
+    def session(self, *, database):
+        self.database = database
+        return self._session
+
+
+@pytest.mark.asyncio
+async def test_execute_neo4j_query_limits_rows_and_returns_metadata():
+    result = FakeResult(
+        ["name", "age"],
+        [
+            FakeRecord(["Alice", 30]),
+            FakeRecord(["Bob", 31]),
+            FakeRecord(["Carol", 32]),
+        ],
+    )
+    session = FakeSession(result)
+    driver = FakeDriver(session)
+
+    response = await execute_neo4j_query(
+        driver,
+        "neo4j",
+        "MATCH (n) RETURN n.name AS name, n.age AS age",
+        {"active": True},
+        limit=2,
+    )
+
+    assert response.columns == ["name", "age"]
+    assert response.rows == [["Alice", 30], ["Bob", 31]]
+    assert response.row_count == 2
+    assert response.truncated is True
+    assert response.elapsed_ms >= 0
+    assert session.query == "MATCH (n) RETURN n.name AS name, n.age AS age"
+    assert session.params == {"active": True}
+    assert driver.database == "neo4j"
+
+
+@pytest.mark.asyncio
+async def test_execute_neo4j_query_uses_empty_params_when_params_is_none():
+    session = FakeSession(FakeResult(["n"], [FakeRecord(["node"])]))
+    driver = FakeDriver(session)
+
+    await execute_neo4j_query(driver, "neo4j", "MATCH (n) RETURN n", params=None, limit=1)
+
+    assert session.params == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_neo4j_query_times_out():
+    session = FakeSession(FakeResult(["n"], [FakeRecord(["node"])]), delay=0.05)
+    driver = FakeDriver(session)
+
+    with pytest.raises(TimeoutError):
+        await execute_neo4j_query(
+            driver,
+            "neo4j",
+            "MATCH (n) RETURN n",
+            limit=1,
+            timeout=0.001,
+        )

--- a/unibridge-service/tests/test_neo4j_query_executor.py
+++ b/unibridge-service/tests/test_neo4j_query_executor.py
@@ -3,7 +3,7 @@ import time
 import pytest
 
 from app.services import query_executor
-from app.services.query_executor import _convert_neo4j_value, execute_neo4j_query
+from app.services.query_executor import _convert_neo4j_value, _neo4j_entity_id, execute_neo4j_query
 
 
 class FakeRecord:
@@ -183,6 +183,14 @@ def test_convert_neo4j_value_uses_iso_format_and_string_fallback():
 
     assert _convert_neo4j_value(IsoFormatOnly()) == "2026-05-02T00:00:00"
     assert _convert_neo4j_value(CustomObject()) == "custom-value"
+
+
+def test_neo4j_entity_id_preserves_falsy_element_id():
+    class Entity:
+        element_id = ""
+        id = 123
+
+    assert _neo4j_entity_id(Entity()) == ""
 
 
 @pytest.mark.asyncio

--- a/unibridge-service/tests/test_neo4j_statement_type.py
+++ b/unibridge-service/tests/test_neo4j_statement_type.py
@@ -1,0 +1,13 @@
+from app.routers.query import _detect_neo4j_statement_type
+
+
+def test_neo4j_statement_type_ignores_keywords_in_labels_and_string_literals():
+    assert _detect_neo4j_statement_type("MATCH (n:Delete) RETURN n") == "select"
+    assert _detect_neo4j_statement_type("RETURN 'DELETE' AS word") == "select"
+    assert _detect_neo4j_statement_type("MATCH (n {action: 'SET'}) RETURN n") == "select"
+
+
+def test_neo4j_statement_type_detects_mutating_clauses():
+    assert _detect_neo4j_statement_type("MATCH (n) DELETE n") == "delete"
+    assert _detect_neo4j_statement_type("MATCH (n) SET n.name = 'x' RETURN n") == "update"
+    assert _detect_neo4j_statement_type("CREATE (:User {name: 'x'})") == "insert"

--- a/unibridge-service/tests/test_neo4j_statement_type.py
+++ b/unibridge-service/tests/test_neo4j_statement_type.py
@@ -7,7 +7,25 @@ def test_neo4j_statement_type_ignores_keywords_in_labels_and_string_literals():
     assert _detect_neo4j_statement_type("MATCH (n {action: 'SET'}) RETURN n") == "select"
 
 
+def test_neo4j_statement_type_detects_read_only_queries():
+    assert _detect_neo4j_statement_type("MATCH (n) RETURN n") == "select"
+    assert _detect_neo4j_statement_type("OPTIONAL MATCH (n) RETURN n") == "select"
+    assert _detect_neo4j_statement_type("RETURN 1 AS value") == "select"
+    assert _detect_neo4j_statement_type("WITH 1 AS value RETURN value") == "select"
+    assert _detect_neo4j_statement_type("UNWIND [1, 2] AS value RETURN value") == "select"
+
+
 def test_neo4j_statement_type_detects_mutating_clauses():
     assert _detect_neo4j_statement_type("MATCH (n) DELETE n") == "delete"
     assert _detect_neo4j_statement_type("MATCH (n) SET n.name = 'x' RETURN n") == "update"
+    assert _detect_neo4j_statement_type("MATCH (n) REMOVE n.name RETURN n") == "update"
     assert _detect_neo4j_statement_type("CREATE (:User {name: 'x'})") == "insert"
+    assert _detect_neo4j_statement_type("MERGE (:User {name: 'x'})") == "insert"
+    assert _detect_neo4j_statement_type("DROP INDEX user_name IF EXISTS") == "execute"
+    assert (
+        _detect_neo4j_statement_type(
+            "LOAD CSV FROM 'file:///users.csv' AS row RETURN row"
+        )
+        == "execute"
+    )
+    assert _detect_neo4j_statement_type("CALL db.labels() YIELD label RETURN label") == "execute"

--- a/unibridge-service/tests/test_query_roles.py
+++ b/unibridge-service/tests/test_query_roles.py
@@ -128,6 +128,9 @@ class TestQueryExecute:
             "app.routers.query.connection_manager.get_neo4j_driver",
             return_value=mock_driver,
         ), patch(
+            "app.routers.query.connection_manager.get_database_name",
+            return_value="neo4j",
+        ), patch(
             "app.routers.query.execute_neo4j_query",
             new_callable=AsyncMock,
             return_value=_mock_query_response(),
@@ -145,7 +148,7 @@ class TestQueryExecute:
         assert resp.json()["row_count"] == 1
         mock_exec.assert_awaited_once_with(
             driver=mock_driver,
-            database="graph",
+            database="neo4j",
             query="MATCH (n) RETURN n",
             params=None,
             limit=None,
@@ -295,10 +298,13 @@ class TestQueryExecute:
             "app.routers.query.connection_manager.get_neo4j_driver",
             return_value=mock_driver,
         ), patch(
+            "app.routers.query.connection_manager.get_database_name",
+            return_value="neo4j",
+        ), patch(
             "app.routers.query.execute_neo4j_query",
             new_callable=AsyncMock,
             return_value=_mock_query_response(),
-        ), patch(
+        ) as mock_exec, patch(
             "app.routers.query.log_query",
             new_callable=AsyncMock,
         ):
@@ -310,6 +316,14 @@ class TestQueryExecute:
 
         assert resp.status_code == 200
         assert resp.json()["row_count"] == 1
+        mock_exec.assert_awaited_once_with(
+            driver=mock_driver,
+            database="neo4j",
+            query="MATCH (n) RETURN n",
+            params=None,
+            limit=None,
+            timeout=None,
+        )
 
     @pytest.mark.parametrize(
         "cypher",

--- a/unibridge-service/tests/test_query_roles.py
+++ b/unibridge-service/tests/test_query_roles.py
@@ -119,6 +119,39 @@ class TestQueryExecute:
         assert data["row_count"] == 1
         mock_exec.assert_awaited_once()
 
+    async def test_admin_executes_neo4j_query_by_alias(self, client, admin_token):
+        mock_driver = MagicMock()
+        with patch(
+            "app.routers.query.connection_manager.get_db_type",
+            return_value="neo4j",
+        ), patch(
+            "app.routers.query.connection_manager.get_neo4j_driver",
+            return_value=mock_driver,
+        ), patch(
+            "app.routers.query.execute_neo4j_query",
+            new_callable=AsyncMock,
+            return_value=_mock_query_response(),
+        ) as mock_exec, patch(
+            "app.routers.query.log_query",
+            new_callable=AsyncMock,
+        ):
+            resp = await client.post(
+                "/query/execute",
+                json={"database": "graph", "sql": "MATCH (n) RETURN n"},
+                headers=auth_header(admin_token),
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["row_count"] == 1
+        mock_exec.assert_awaited_once_with(
+            driver=mock_driver,
+            database="graph",
+            query="MATCH (n) RETURN n",
+            params=None,
+            limit=None,
+            timeout=None,
+        )
+
     async def test_successful_query_survives_audit_write_failure(
         self, client, admin_token
     ):
@@ -208,6 +241,70 @@ class TestQueryExecute:
             resp = await client.post(
                 "/query/execute",
                 json={"database": "devdb", "sql": "SELECT * FROM users"},
+                headers=auth_header(developer_token),
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["row_count"] == 1
+
+    async def test_developer_can_execute_neo4j_match_with_permission_entry(
+        self, client, admin_token, developer_token
+    ):
+        with patch(
+            "app.routers.admin.connection_manager.add_connection",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.routers.admin.connection_manager.get_status",
+            return_value={"status": "registered"},
+        ):
+            resp = await client.post(
+                "/admin/query/databases",
+                json={
+                    "alias": "graph",
+                    "db_type": "neo4j",
+                    "host": "neo4j.internal",
+                    "port": 7687,
+                    "database": "neo4j",
+                    "username": "neo4j",
+                    "password": "pass",
+                    "protocol": "bolt",
+                },
+                headers=auth_header(admin_token),
+            )
+            assert resp.status_code == 201
+
+        resp = await client.put(
+            "/admin/query/permissions",
+            json={
+                "role": "developer",
+                "db_alias": "graph",
+                "allow_select": True,
+                "allow_insert": False,
+                "allow_update": False,
+                "allow_delete": False,
+            },
+            headers=auth_header(admin_token),
+        )
+        assert resp.status_code == 200
+
+        mock_driver = MagicMock()
+        with patch(
+            "app.routers.query.connection_manager.get_db_type",
+            return_value="neo4j",
+        ), patch(
+            "app.routers.query.connection_manager.get_neo4j_driver",
+            return_value=mock_driver,
+        ), patch(
+            "app.routers.query.execute_neo4j_query",
+            new_callable=AsyncMock,
+            return_value=_mock_query_response(),
+        ), patch(
+            "app.routers.query.log_query",
+            new_callable=AsyncMock,
+        ):
+            resp = await client.post(
+                "/query/execute",
+                json={"database": "graph", "sql": "MATCH (n) RETURN n"},
                 headers=auth_header(developer_token),
             )
 

--- a/unibridge-service/tests/test_query_roles.py
+++ b/unibridge-service/tests/test_query_roles.py
@@ -155,6 +155,43 @@ class TestQueryExecute:
             timeout=None,
         )
 
+    @pytest.mark.parametrize(
+        "cypher",
+        [
+            "CREATE (:User {name: 'x'})",
+            "MERGE (:User {name: 'x'})",
+            "MATCH (n) SET n.name = 'x' RETURN n",
+            "MATCH (n) REMOVE n.name RETURN n",
+            "MATCH (n) DELETE n",
+            "DROP INDEX user_name IF EXISTS",
+            "LOAD CSV FROM 'file:///users.csv' AS row RETURN row",
+            "CALL db.labels() YIELD label RETURN label",
+        ],
+    )
+    async def test_admin_cannot_execute_mutating_neo4j_query(
+        self, client, admin_token, cypher
+    ):
+        with patch(
+            "app.routers.query.connection_manager.get_db_type",
+            return_value="neo4j",
+        ), patch(
+            "app.routers.query.connection_manager.get_neo4j_driver",
+            return_value=MagicMock(),
+        ), patch(
+            "app.routers.query.execute_neo4j_query",
+            new_callable=AsyncMock,
+            return_value=_mock_query_response(),
+        ) as mock_exec:
+            resp = await client.post(
+                "/query/execute",
+                json={"database": "graph", "sql": cypher},
+                headers=auth_header(admin_token),
+            )
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Neo4j queries are read-only"
+        mock_exec.assert_not_awaited()
+
     async def test_successful_query_survives_audit_write_failure(
         self, client, admin_token
     ):
@@ -448,7 +485,7 @@ class TestQueryExecute:
             )
 
         assert resp.status_code == 403
-        assert resp.json()["detail"] == "API key users can only execute SELECT queries"
+        assert resp.json()["detail"] == "Neo4j queries are read-only"
         mock_exec.assert_not_awaited()
 
     async def test_developer_without_permission_entry_gets_403(

--- a/unibridge-service/tests/test_query_roles.py
+++ b/unibridge-service/tests/test_query_roles.py
@@ -311,6 +311,132 @@ class TestQueryExecute:
         assert resp.status_code == 200
         assert resp.json()["row_count"] == 1
 
+    @pytest.mark.parametrize(
+        "cypher",
+        [
+            "MATCH (n) DELETE n",
+            "MATCH (n) SET n.name = 'x' RETURN n",
+            "CREATE (:User {name: 'x'})",
+        ],
+    )
+    async def test_developer_select_only_cannot_execute_mutating_neo4j_query(
+        self, client, admin_token, developer_token, cypher
+    ):
+        with patch(
+            "app.routers.admin.connection_manager.add_connection",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.routers.admin.connection_manager.get_status",
+            return_value={"status": "registered"},
+        ):
+            resp = await client.post(
+                "/admin/query/databases",
+                json={
+                    "alias": "graph",
+                    "db_type": "neo4j",
+                    "host": "neo4j.internal",
+                    "port": 7687,
+                    "database": "neo4j",
+                    "username": "neo4j",
+                    "password": "pass",
+                    "protocol": "bolt",
+                },
+                headers=auth_header(admin_token),
+            )
+            assert resp.status_code == 201
+
+        resp = await client.put(
+            "/admin/query/permissions",
+            json={
+                "role": "developer",
+                "db_alias": "graph",
+                "allow_select": True,
+                "allow_insert": False,
+                "allow_update": False,
+                "allow_delete": False,
+            },
+            headers=auth_header(admin_token),
+        )
+        assert resp.status_code == 200
+
+        with patch(
+            "app.routers.query.connection_manager.get_db_type",
+            return_value="neo4j",
+        ), patch(
+            "app.routers.query.connection_manager.get_neo4j_driver",
+            return_value=MagicMock(),
+        ), patch(
+            "app.routers.query.execute_neo4j_query",
+            new_callable=AsyncMock,
+            return_value=_mock_query_response(),
+        ) as mock_exec:
+            resp = await client.post(
+                "/query/execute",
+                json={"database": "graph", "sql": cypher},
+                headers=auth_header(developer_token),
+            )
+
+        assert resp.status_code == 403
+        mock_exec.assert_not_awaited()
+
+    async def test_apikey_cannot_execute_mutating_neo4j_query(
+        self, client, admin_token
+    ):
+        with patch("app.routers.api_keys.apisix_client") as mock_apisix:
+            mock_apisix.put_resource = AsyncMock(
+                return_value={
+                    "username": "graph-app",
+                    "plugins": {"key-auth": {"key": "graph-key"}},
+                }
+            )
+            mock_apisix.get_resource = AsyncMock(side_effect=Exception("not found"))
+            mock_apisix.list_resources = AsyncMock(
+                return_value={
+                    "items": [
+                        {
+                            "id": "query-api",
+                            "uri": "/query/*",
+                            "plugins": {
+                                "key-auth": {},
+                                "consumer-restriction": {"whitelist": []},
+                            },
+                        }
+                    ]
+                }
+            )
+            resp = await client.post(
+                "/admin/api-keys",
+                json={
+                    "name": "graph-app",
+                    "api_key": "graph-key",
+                    "allowed_databases": ["graph"],
+                    "allowed_routes": ["query-api"],
+                },
+                headers=auth_header(admin_token),
+            )
+            assert resp.status_code == 201
+
+        with patch(
+            "app.routers.query.connection_manager.get_db_type",
+            return_value="neo4j",
+        ), patch(
+            "app.routers.query.connection_manager.get_neo4j_driver",
+            return_value=MagicMock(),
+        ), patch(
+            "app.routers.query.execute_neo4j_query",
+            new_callable=AsyncMock,
+            return_value=_mock_query_response(),
+        ) as mock_exec:
+            resp = await client.post(
+                "/query/execute",
+                json={"database": "graph", "sql": "MATCH (n) DELETE n"},
+                headers={"X-Consumer-Username": "graph-app"},
+            )
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "API key users can only execute SELECT queries"
+        mock_exec.assert_not_awaited()
+
     async def test_developer_without_permission_entry_gets_403(
         self, client, developer_token
     ):


### PR DESCRIPTION
## Summary
- Add `neo4j` database connection registration with Bolt/Neo4j URI protocol validation.
- Manage Neo4j drivers by UniBridge alias and route `/query/execute` Cypher requests through the configured Neo4j database name.
- Add basic Cypher execution with safe parameter passing, result serialization, timeout handling, and mutating Cypher authorization checks.

## Test Plan
- [x] `cd unibridge-service && .venv/bin/python -m pytest tests/test_admin.py::TestCreateConnection tests/test_connection_manager_neo4j.py tests/test_neo4j_query_executor.py tests/test_query_roles.py::TestQueryExecute -v` → 38 passed
- [x] `cd unibridge-service && .venv/bin/python -m pytest -q` → 859 passed, 2 warnings