### PR TITLE
feat(alerts): 연속 실패 횟수(N-strike) 설정 가능하도록

### DIFF
--- a/unibridge-service/alembic/versions/0005_alert_trigger_after_failures.py
+++ b/unibridge-service/alembic/versions/0005_alert_trigger_after_failures.py
@@ -3,6 +3,14 @@
 Revision ID: 0005_alert_trigger_after_failures
 Revises: 0004_alert_owner_routing
 Create Date: 2026-05-11
+
+Upgrade collapses the legacy two-state distinction (alert+notified vs
+alert+unnotified) into a single counter, which is intentionally lossy:
+the pre-notification state (alert, alert_notified=FALSE) is rewritten to
+(ok, fail_count=N-1). Downgrade cannot reconstruct the original row from
+that compacted shape — (ok, fail_count>0) is also a legitimate steady
+state under the new model — so the downgrade restores alert_notified
+conservatively (TRUE for ok rows, matching the old default).
 """
 from __future__ import annotations
 
@@ -87,6 +95,11 @@ def downgrade() -> None:
             )
         )
 
+    # Best-effort restore: alert rows recover their notified flag from
+    # fail_count; ok rows always become alert_notified=TRUE because the
+    # upgrade's collapse of (alert, FALSE) → (ok, fail_count=N-1) is
+    # one-way (see module docstring). Rolling forward and back on a row
+    # that started as (alert, FALSE) yields (ok, TRUE), not the original.
     op.execute(sa.text(
         """
         UPDATE alert_state

--- a/unibridge-service/alembic/versions/0005_alert_trigger_after_failures.py
+++ b/unibridge-service/alembic/versions/0005_alert_trigger_after_failures.py
@@ -1,0 +1,111 @@
+"""Add trigger_after_failures and replace alert_notified with fail_count.
+
+Revision ID: 0005_alert_trigger_after_failures
+Revises: 0004_alert_owner_routing
+Create Date: 2026-05-11
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0005_alert_trigger_after_failures"
+down_revision = "0004_alert_owner_routing"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("alert_settings") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "trigger_after_failures",
+                sa.Integer(),
+                nullable=False,
+                server_default="2",
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_alert_settings_trigger_after_failures_range",
+            "trigger_after_failures BETWEEN 1 AND 10",
+        )
+
+    with op.batch_alter_table("alert_state") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "fail_count",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            )
+        )
+
+    # Backfill fail_count from the legacy (status, alert_notified) pair using the
+    # configured N. If alert_settings is empty (fresh deploy mid-migration), fall
+    # back to N=2 — the new column's server default.
+    op.execute(sa.text(
+        """
+        UPDATE alert_state
+        SET fail_count = CASE
+            WHEN status = 'alert' AND alert_notified = TRUE THEN
+                COALESCE((SELECT trigger_after_failures FROM alert_settings WHERE id = 1), 2)
+            WHEN status = 'alert' AND alert_notified = FALSE THEN
+                CASE
+                    WHEN COALESCE((SELECT trigger_after_failures FROM alert_settings WHERE id = 1), 2) - 1 < 0
+                        THEN 0
+                    ELSE COALESCE((SELECT trigger_after_failures FROM alert_settings WHERE id = 1), 2) - 1
+                END
+            ELSE 0
+        END
+        """
+    ))
+
+    # Tracked-but-unnotified alerts: under the new model they live as ok with
+    # accumulated fail_count, awaiting one more failure to fire.
+    op.execute(sa.text(
+        """
+        UPDATE alert_state
+        SET status = 'ok',
+            since = COALESCE(updated_at, since)
+        WHERE status = 'alert' AND alert_notified = FALSE
+        """
+    ))
+
+    with op.batch_alter_table("alert_state") as batch_op:
+        batch_op.drop_column("alert_notified")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("alert_state") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "alert_notified",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            )
+        )
+
+    op.execute(sa.text(
+        """
+        UPDATE alert_state
+        SET alert_notified = CASE
+            WHEN status = 'alert' AND fail_count >= COALESCE(
+                (SELECT trigger_after_failures FROM alert_settings WHERE id = 1), 2
+            ) THEN TRUE
+            WHEN status = 'alert' THEN FALSE
+            ELSE TRUE
+        END
+        """
+    ))
+
+    with op.batch_alter_table("alert_state") as batch_op:
+        batch_op.drop_column("fail_count")
+
+    with op.batch_alter_table("alert_settings") as batch_op:
+        batch_op.drop_constraint(
+            "ck_alert_settings_trigger_after_failures_range",
+            type_="check",
+        )
+        batch_op.drop_column("trigger_after_failures")

--- a/unibridge-service/app/database.py
+++ b/unibridge-service/app/database.py
@@ -13,7 +13,7 @@ from app.config import settings
 from app.models import Base
 
 ALEMBIC_BASELINE_REVISION = "0001_initial"
-ALEMBIC_HEAD_REVISION = "0004_alert_owner_routing"
+ALEMBIC_HEAD_REVISION = "0005_alert_trigger_after_failures"
 _SERVICE_ROOT = Path(__file__).resolve().parents[1]
 
 # Ensure the data directory exists for SQLite

--- a/unibridge-service/app/models.py
+++ b/unibridge-service/app/models.py
@@ -217,10 +217,20 @@ class AlertSettings(Base):
     fallback_owner_group_id = Column(Integer, ForeignKey("owner_groups.id", ondelete="RESTRICT"), nullable=True)
     route_error_threshold_pct = Column(Float, default=10.0, nullable=False, server_default="10.0")
     check_interval_seconds = Column(Integer, default=60, nullable=False, server_default="60")
+    trigger_after_failures = Column(
+        Integer,
+        default=2,
+        nullable=False,
+        server_default="2",
+    )
     updated_at = Column(UtcDateTime, default=utcnow, onupdate=utcnow, nullable=False)
 
     __table_args__ = (
         CheckConstraint("id = 1", name="ck_alert_settings_singleton"),
+        CheckConstraint(
+            "trigger_after_failures BETWEEN 1 AND 10",
+            name="ck_alert_settings_trigger_after_failures_range",
+        ),
     )
 
 

--- a/unibridge-service/app/models.py
+++ b/unibridge-service/app/models.py
@@ -260,7 +260,7 @@ class AlertState(Base):
     status = Column(String(20), nullable=False)
     since = Column(UtcDateTime, default=utcnow, nullable=False)
     display_target = Column(String(200), nullable=True)
-    alert_notified = Column(Boolean, default=True, nullable=False, server_default="true")
+    fail_count = Column(Integer, default=0, nullable=False, server_default="0")
     updated_at = Column(UtcDateTime, default=utcnow, onupdate=utcnow)
 
     __table_args__ = (

--- a/unibridge-service/app/routers/alerts.py
+++ b/unibridge-service/app/routers/alerts.py
@@ -75,6 +75,7 @@ async def _get_or_create_alert_settings(
             id=1,
             route_error_threshold_pct=10.0,
             check_interval_seconds=60,
+            trigger_after_failures=2,
         )
         db.add(settings)
         try:
@@ -222,6 +223,8 @@ async def update_alert_settings(
         settings.route_error_threshold_pct = body.route_error_threshold_pct
     if body.check_interval_seconds is not None:
         settings.check_interval_seconds = body.check_interval_seconds
+    if body.trigger_after_failures is not None:
+        settings.trigger_after_failures = body.trigger_after_failures
     await db.commit()
     await db.refresh(settings)
     return AlertSettingsResponse.model_validate(settings)

--- a/unibridge-service/app/schemas.py
+++ b/unibridge-service/app/schemas.py
@@ -328,6 +328,7 @@ class AlertSettingsResponse(BaseModel):
     fallback_owner_group_id: int | None = None
     route_error_threshold_pct: float
     check_interval_seconds: int
+    trigger_after_failures: int
     updated_at: datetime | None = None
 
     model_config = {"from_attributes": True}
@@ -338,10 +339,15 @@ class AlertSettingsUpdate(BaseModel):
     fallback_owner_group_id: int | None = None
     route_error_threshold_pct: float | None = Field(None, ge=0, le=100)
     check_interval_seconds: int | None = Field(None, ge=30, le=3600)
+    trigger_after_failures: int | None = Field(None, ge=1, le=10)
 
     @model_validator(mode="after")
     def reject_explicit_numeric_nulls(self) -> "AlertSettingsUpdate":
-        for field_name in ("route_error_threshold_pct", "check_interval_seconds"):
+        for field_name in (
+            "route_error_threshold_pct",
+            "check_interval_seconds",
+            "trigger_after_failures",
+        ):
             if field_name in self.model_fields_set and getattr(self, field_name) is None:
                 raise ValueError(f"{field_name} cannot be null")
         return self

--- a/unibridge-service/app/services/alert_checker.py
+++ b/unibridge-service/app/services/alert_checker.py
@@ -42,6 +42,21 @@ async def _get_check_interval_seconds() -> int:
     return min(3600, max(30, int(interval)))
 
 
+async def _get_trigger_after_failures() -> int:
+    try:
+        async with async_session() as db:
+            result = await db.execute(
+                select(AlertSettings.trigger_after_failures).where(AlertSettings.id == 1)
+            )
+            value = result.scalar_one_or_none()
+    except Exception as exc:
+        logger.warning("Failed to load alert trigger_after_failures: %s", exc)
+        return 2
+    if value is None:
+        return 2
+    return min(10, max(1, int(value)))
+
+
 def _normalize_route_error_threshold_pct(value: float | int | None) -> float:
     if value is None:
         return 10.0
@@ -366,6 +381,7 @@ async def _evaluate_route_error_rule(
     route_id: str,
     rate: float,
     rule: AlertRule,
+    trigger_after_failures: int,
     display_target: str | None = None,
     default_threshold: float = 10.0,
 ) -> None:
@@ -379,8 +395,11 @@ async def _evaluate_route_error_rule(
     is_healthy = rate < threshold
     state_target = _route_state_target(route_id, rule.id)
     transition = state.update(
-        "route_error_rate", state_target, is_healthy=is_healthy,
+        "route_error_rate",
+        state_target,
+        is_healthy=is_healthy,
         display_target=display,
+        trigger_after_failures=trigger_after_failures,
     )
     await _persist_state_safely(state, "route_error_rate", state_target)
     if transition:
@@ -398,12 +417,16 @@ async def _evaluate_route_error_rule(
         )
 
 
-async def run_single_check(state: AlertStateManager) -> None:
+async def run_single_check(state: AlertStateManager, *, trigger_after_failures: int) -> None:
     """Execute one round of all health checks."""
     # 1. DB health
     db_results = await _check_db_health()
     for alias, is_healthy in db_results:
-        transition = state.update("db_health", alias, is_healthy=is_healthy)
+        transition = state.update(
+            "db_health", alias,
+            is_healthy=is_healthy,
+            trigger_after_failures=trigger_after_failures,
+        )
         await _persist_state_safely(state, "db_health", alias)
         if transition:
             msg = f"Database '{alias}' connection {'restored' if transition == 'resolved' else 'failed'}."
@@ -419,8 +442,10 @@ async def run_single_check(state: AlertStateManager) -> None:
         upstream_name = _UPSTREAM_NAME_BY_ID.get(uid)
         display = f"{upstream_name} ({uid})" if upstream_name and upstream_name != uid else uid
         transition = state.update(
-            "upstream_health", uid, is_healthy=is_healthy,
+            "upstream_health", uid,
+            is_healthy=is_healthy,
             display_target=display,
+            trigger_after_failures=trigger_after_failures,
         )
         await _persist_state_safely(state, "upstream_health", uid)
         if transition:
@@ -444,15 +469,14 @@ async def run_single_check(state: AlertStateManager) -> None:
             rules = result.scalars().all()
 
         for rule in rules:
-            # Honor explicit threshold=0 (user wants aggressive alerting).
-            # Use `is not None` instead of `or` so 0.0 is not treated as falsy.
             threshold = rule.threshold if rule.threshold is not None else 10.0
             is_healthy = rate < threshold
-            # Use rule ID in state key so multiple rules with different thresholds don't collide
             state_target = f"{target_name}:rule_{rule.id}"
             transition = state.update(
-                "error_rate", state_target, is_healthy=is_healthy,
+                "error_rate", state_target,
+                is_healthy=is_healthy,
                 display_target=target_name,
+                trigger_after_failures=trigger_after_failures,
             )
             await _persist_state_safely(state, "error_rate", state_target)
             if transition:
@@ -501,6 +525,7 @@ async def run_single_check(state: AlertStateManager) -> None:
                     route_id=route_id,
                     rate=rate,
                     rule=rule,
+                    trigger_after_failures=trigger_after_failures,
                     default_threshold=route_default_threshold,
                 )
 
@@ -522,6 +547,7 @@ async def run_single_check(state: AlertStateManager) -> None:
                 route_id=route_id,
                 rate=0.0,
                 rule=rule,
+                trigger_after_failures=trigger_after_failures,
                 display_target=entry.get("display_target"),
                 default_threshold=route_default_threshold,
             )
@@ -534,8 +560,9 @@ async def start_checker(state: AlertStateManager) -> asyncio.Task:
         while True:
             cycle_start = _monotonic()
             check_interval = await _get_check_interval_seconds()
+            trigger_after_failures = await _get_trigger_after_failures()
             try:
-                await run_single_check(state)
+                await run_single_check(state, trigger_after_failures=trigger_after_failures)
             except Exception:
                 logger.exception("Alert checker cycle failed")
             elapsed = _monotonic() - cycle_start

--- a/unibridge-service/app/services/alert_state.py
+++ b/unibridge-service/app/services/alert_state.py
@@ -22,8 +22,8 @@ def _rule_state_suffix(rule_id: int) -> str:
 class AlertStateManager:
     """In-memory alert state tracker.
 
-    Tracks (type, target) → status transitions.
-    Returns transition type on state change, None if no change.
+    Each entry: status ∈ {"ok", "alert"}, fail_count is the consecutive
+    failure tally, since is the timestamp of the most recent status flip.
     """
 
     def __init__(self) -> None:
@@ -43,7 +43,7 @@ class AlertStateManager:
             "status": entry["status"],
             "since": entry["since"],
             "display_target": entry.get("display_target", target),
-            "alert_notified": entry.get("alert_notified", True),
+            "fail_count": entry.get("fail_count", 0),
         }
 
     def set_entry(
@@ -54,71 +54,95 @@ class AlertStateManager:
         status: str,
         since: str,
         display_target: str | None = None,
-        alert_notified: bool = True,
+        fail_count: int = 0,
     ) -> None:
         self._states[(alert_type, target)] = {
             "status": status,
             "since": since,
             "display_target": display_target or target,
-            "alert_notified": alert_notified,
+            "fail_count": fail_count,
         }
 
     def update(
-        self, alert_type: str, target: str, *, is_healthy: bool, display_target: str | None = None,
+        self,
+        alert_type: str,
+        target: str,
+        *,
+        is_healthy: bool,
+        trigger_after_failures: int,
+        display_target: str | None = None,
     ) -> str | None:
         """Update state and return transition type if changed.
 
-        Args:
-            alert_type: Check type (db_health, upstream_health, error_rate).
-            target: Internal state key (may include rule ID for scoping).
-            is_healthy: Whether the check passed.
-            display_target: Human-readable target name for API display.
-                            Defaults to target if not provided.
-
-        Returns:
-            "triggered" — transitioned ok → alert
-            "resolved"  — transitioned alert → ok
-            None        — no change
+        Returns "triggered" / "resolved" / None. fail_count drives status:
+        flip to "alert" only when fail_count reaches trigger_after_failures.
         """
         key = (alert_type, target)
-        current = self._states.get(key)
-        new_status = "ok" if is_healthy else "alert"
         now = datetime.now(timezone.utc).isoformat()
+        entry = self._states.get(key)
 
-        if current is None:
+        if entry is None:
+            if is_healthy:
+                self._states[key] = {
+                    "status": "ok",
+                    "since": now,
+                    "display_target": display_target or target,
+                    "fail_count": 0,
+                }
+                logger.info("Alert state %s/%s initialized as ok", alert_type, target)
+                return None
+            fail_count = 1
+            if fail_count >= trigger_after_failures:
+                self._states[key] = {
+                    "status": "alert",
+                    "since": now,
+                    "display_target": display_target or target,
+                    "fail_count": fail_count,
+                }
+                logger.info("Alert state %s/%s initialized as alert", alert_type, target)
+                return "triggered"
             self._states[key] = {
-                "status": new_status,
+                "status": "ok",
                 "since": now,
                 "display_target": display_target or target,
-                "alert_notified": is_healthy,
+                "fail_count": fail_count,
             }
-            logger.info("Alert state %s/%s initialized as %s", alert_type, target, new_status)
+            logger.info(
+                "Alert state %s/%s initialized as ok (fail_count=%d)",
+                alert_type, target, fail_count,
+            )
             return None
 
-        current_status = current["status"]
-        if current_status == new_status:
-            if new_status == "alert" and not current.get("alert_notified", True):
-                current["alert_notified"] = True
-                logger.info("Alert state %s/%s: initial alert confirmed", alert_type, target)
-                return "triggered"
+        # Update display_target on every observation so renames propagate.
+        if display_target is not None:
+            entry["display_target"] = display_target
+
+        if is_healthy:
+            was_alert = entry["status"] == "alert"
+            entry["fail_count"] = 0
+            if was_alert:
+                entry["status"] = "ok"
+                entry["since"] = now
+                logger.info("Alert state %s/%s: alert → ok", alert_type, target)
+                return "resolved"
             return None
 
-        alert_was_notified = current.get("alert_notified", True)
-        self._states[key] = {
-            "status": new_status,
-            "since": now,
-            "display_target": display_target or target,
-            "alert_notified": True,
-        }
-        if is_healthy and not alert_was_notified:
-            transition = None
-        else:
-            transition = "resolved" if is_healthy else "triggered"
-        logger.info("Alert state %s/%s: %s → %s", alert_type, target, current_status, new_status)
-        return transition
+        # unhealthy
+        entry["fail_count"] = entry.get("fail_count", 0) + 1
+        if entry["status"] == "alert":
+            entry["fail_count"] = min(entry["fail_count"], trigger_after_failures)
+            return None
+        if entry["fail_count"] >= trigger_after_failures:
+            entry["status"] = "alert"
+            entry["since"] = now
+            logger.info(
+                "Alert state %s/%s: ok → alert (fail_count=%d, threshold=%d)",
+                alert_type, target, entry["fail_count"], trigger_after_failures,
+            )
+            return "triggered"
+        return None
 
     def get_all_alerts(self) -> list[dict]:
-        """Return all entries currently in 'alert' status."""
         return [
             {
                 "type": k[0],
@@ -131,7 +155,6 @@ class AlertStateManager:
         ]
 
     def get_all_statuses(self) -> list[dict]:
-        """Return all known entries, including both ok and alert states."""
         return [
             {
                 "type": k[0],
@@ -148,7 +171,6 @@ class AlertStateManager:
         alert_type: str | None = None,
         status: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Return internal state entries for checker coordination."""
         rows: list[dict[str, Any]] = []
         for (entry_type, target), entry in self._states.items():
             if alert_type is not None and entry_type != alert_type:
@@ -161,12 +183,11 @@ class AlertStateManager:
                 "status": entry["status"],
                 "since": entry["since"],
                 "display_target": entry.get("display_target", target),
-                "alert_notified": entry.get("alert_notified", True),
+                "fail_count": entry.get("fail_count", 0),
             })
         return rows
 
     def clear_rule_states(self, rule_id: int) -> None:
-        """Remove in-memory states whose key is scoped to an alert rule."""
         suffix = _rule_state_suffix(rule_id)
         for key in list(self._states):
             alert_type, target = key
@@ -212,7 +233,7 @@ async def save_alert_state_to_db(
     row.status = entry["status"]
     row.since = _parse_since(entry["since"])
     row.display_target = entry["display_target"]
-    row.alert_notified = bool(entry["alert_notified"])
+    row.fail_count = int(entry["fail_count"])
     row.updated_at = utcnow()
     await db.commit()
 
@@ -237,7 +258,7 @@ async def load_alert_state_from_db(
             status=row.status,
             since=since.isoformat(),
             display_target=row.display_target,
-            alert_notified=row.alert_notified,
+            fail_count=row.fail_count,
         )
 
 

--- a/unibridge-service/tests/test_alert_checker.py
+++ b/unibridge-service/tests/test_alert_checker.py
@@ -103,7 +103,8 @@ class TestAlertChecker:
     @pytest.mark.asyncio
     async def test_db_health_triggered(self):
         state = AlertStateManager()
-        state.update("db_health", "mydb", is_healthy=True)
+        # Seed fail_count=1 so the next unhealthy observation crosses N=2.
+        state.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
 
         with patch("app.services.alert_checker._check_db_health", new_callable=AsyncMock) as mock_db, \
              patch("app.services.alert_checker._check_upstream_health", new_callable=AsyncMock) as mock_up, \
@@ -114,7 +115,7 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
             assert state.get_status("db_health", "mydb") == "alert"
             mock_dispatch.assert_called_once()
@@ -129,8 +130,8 @@ class TestAlertChecker:
     @pytest.mark.asyncio
     async def test_db_health_resolved(self):
         state = AlertStateManager()
-        state.update("db_health", "mydb", is_healthy=False)
-        state.update("db_health", "mydb", is_healthy=False)
+        state.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        state.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
 
         with patch("app.services.alert_checker._check_db_health", new_callable=AsyncMock) as mock_db, \
              patch("app.services.alert_checker._check_upstream_health", new_callable=AsyncMock) as mock_up, \
@@ -141,7 +142,7 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
             assert state.get_status("db_health", "mydb") == "ok"
             mock_dispatch.assert_called_once()
@@ -166,14 +167,15 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
             mock_dispatch.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_upstream_health_triggered(self):
         state = AlertStateManager()
-        state.update("upstream_health", "order-svc", is_healthy=True)
+        # Seed fail_count=1 so the next unhealthy observation crosses N=2.
+        state.update("upstream_health", "order-svc", is_healthy=False, trigger_after_failures=2)
 
         with patch("app.services.alert_checker._check_db_health", new_callable=AsyncMock) as mock_db, \
              patch("app.services.alert_checker._check_upstream_health", new_callable=AsyncMock) as mock_up, \
@@ -184,7 +186,7 @@ class TestAlertChecker:
             mock_up.return_value = [("order-svc", False)]
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
             assert state.get_status("upstream_health", "order-svc") == "alert"
             mock_dispatch.assert_called_once()
@@ -201,7 +203,8 @@ class TestAlertChecker:
         from app.services import alert_checker
 
         state = AlertStateManager()
-        state.update("upstream_health", "upstream-1", is_healthy=True)
+        # Seed fail_count=1 so the next unhealthy observation crosses N=2.
+        state.update("upstream_health", "upstream-1", is_healthy=False, trigger_after_failures=2)
         alert_checker._UPSTREAM_NAME_BY_ID = {"upstream-1": "payments-api"}
 
         try:
@@ -214,7 +217,7 @@ class TestAlertChecker:
                 mock_up.return_value = [("upstream-1", False)]
                 mock_err.return_value = []
 
-                await run_single_check(state)
+                await run_single_check(state, trigger_after_failures=2)
 
                 mock_dispatch.assert_called_once()
                 kwargs = mock_dispatch.call_args.kwargs
@@ -238,14 +241,15 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
             mock_dispatch.assert_not_called()
-            assert state.get_status("db_health", "boot-db") == "alert"
+            assert state.get_status("db_health", "boot-db") == "ok"
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
             mock_dispatch.assert_called_once()
             assert mock_dispatch.call_args.kwargs["alert_type"] == "triggered"
             assert mock_dispatch.call_args.kwargs["target"] == "boot-db"
+            assert state.get_status("db_health", "boot-db") == "alert"
 
     @pytest.mark.asyncio
     async def test_initial_unhealthy_db_recovery_does_not_send_resolved_without_trigger(self):
@@ -260,8 +264,8 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
+            await run_single_check(state, trigger_after_failures=2)
 
         mock_dispatch.assert_not_called()
         assert state.get_status("db_health", "boot-db") == "ok"
@@ -269,11 +273,13 @@ class TestAlertChecker:
     @pytest.mark.asyncio
     async def test_route_error_rate_dispatches_owner_alert_with_rule_context(self):
         state = AlertStateManager()
+        # Seed fail_count=1 so the next unhealthy observation crosses N=2.
         state.update(
             "route_error_rate",
             "route-a:rule_42",
-            is_healthy=True,
+            is_healthy=False,
             display_target="checkout (route-a)",
+            trigger_after_failures=2,
         )
 
         fake_db = SimpleNamespace(
@@ -298,7 +304,7 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
         mock_dispatch.assert_called_once()
         kwargs = mock_dispatch.call_args.kwargs
@@ -316,11 +322,13 @@ class TestAlertChecker:
     @pytest.mark.asyncio
     async def test_route_error_rate_uses_settings_threshold_when_rule_threshold_missing(self):
         state = AlertStateManager()
+        # Seed fail_count=1 so the next unhealthy observation crosses N=2.
         state.update(
             "route_error_rate",
             "route-a:rule_42",
-            is_healthy=True,
+            is_healthy=False,
             display_target="checkout (route-a)",
+            trigger_after_failures=2,
         )
         rule = SimpleNamespace(
             id=42,
@@ -346,7 +354,7 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
         mock_dispatch.assert_called_once()
         kwargs = mock_dispatch.call_args.kwargs
@@ -356,7 +364,8 @@ class TestAlertChecker:
     @pytest.mark.asyncio
     async def test_global_error_rate_preserves_legacy_rule_dispatch(self):
         state = AlertStateManager()
-        state.update("error_rate", "global:rule_9", is_healthy=True, display_target="global")
+        # Seed fail_count=1 so the next unhealthy observation crosses N=2.
+        state.update("error_rate", "global:rule_9", is_healthy=False, display_target="global", trigger_after_failures=2)
         rule = SimpleNamespace(id=9, target="global", threshold=10.0, name="global 5xx")
         fake_db = SimpleNamespace(execute=AsyncMock(return_value=_FakeResult([rule])))
 
@@ -371,7 +380,7 @@ class TestAlertChecker:
             mock_up.return_value = []
             mock_err.return_value = [("global", 12.5)]
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
         legacy_dispatch.assert_called_once()
         owner_dispatch.assert_not_called()
@@ -530,12 +539,24 @@ class TestCheckRouteErrorRate:
             "route-a:rule_42",
             is_healthy=True,
             display_target="checkout (route-a)",
+            trigger_after_failures=2,
         )
         state.update(
             "route_error_rate",
             "route-a:rule_42",
             is_healthy=False,
             display_target="checkout (route-a)",
+            trigger_after_failures=2,
+        )
+        # With N=2, one unhealthy isn't enough — push a second so the entry
+        # is actually in 'alert' status, which is the precondition for
+        # resolution dispatch on the next healthy observation.
+        state.update(
+            "route_error_rate",
+            "route-a:rule_42",
+            is_healthy=False,
+            display_target="checkout (route-a)",
+            trigger_after_failures=2,
         )
 
         fake_db = SimpleNamespace(
@@ -554,7 +575,7 @@ class TestCheckRouteErrorRate:
             mock_up.return_value = []
             mock_err.return_value = []
 
-            await run_single_check(state)
+            await run_single_check(state, trigger_after_failures=2)
 
         mock_dispatch.assert_called_once()
         kwargs = mock_dispatch.call_args.kwargs
@@ -651,3 +672,44 @@ class TestRouteLabelCache:
         finally:
             alert_checker._ROUTE_LABEL_CACHE = {}
             alert_checker._ROUTE_LABEL_CACHE_TS = 0.0
+
+
+@pytest.mark.asyncio
+async def test_run_single_check_respects_trigger_after_failures(monkeypatch, seeded_db):
+    """With N=3, two consecutive unhealthy cycles must not dispatch; the third does."""
+    from app.services import alert_checker
+    from app.services.alert_state import AlertStateManager
+
+    async def _async_return(value):
+        return value
+
+    monkeypatch.setattr(
+        alert_checker,
+        "_check_db_health",
+        lambda: _async_return([("main-db", False)]),
+    )
+    monkeypatch.setattr(
+        alert_checker, "_check_upstream_health", lambda: _async_return([]),
+    )
+    monkeypatch.setattr(
+        alert_checker, "_check_error_rate", lambda: _async_return([]),
+    )
+    monkeypatch.setattr(
+        alert_checker, "_check_route_error_rate", lambda: _async_return([]),
+    )
+
+    dispatched: list[str] = []
+
+    async def fake_dispatch_owner_alert(**kwargs):
+        dispatched.append(kwargs["alert_type"])
+
+    monkeypatch.setattr(
+        alert_checker, "dispatch_owner_alert", fake_dispatch_owner_alert,
+    )
+
+    state = AlertStateManager()
+    await alert_checker.run_single_check(state, trigger_after_failures=3)
+    await alert_checker.run_single_check(state, trigger_after_failures=3)
+    assert dispatched == []
+    await alert_checker.run_single_check(state, trigger_after_failures=3)
+    assert dispatched == ["triggered"]

--- a/unibridge-service/tests/test_alerts.py
+++ b/unibridge-service/tests/test_alerts.py
@@ -140,54 +140,91 @@ class TestAlertPermissions:
         assert "alerts.write" in ALL_PERMISSIONS
 
 class TestAlertState:
+    """N-strike behavior. Defaults to N=2 (matching production default)."""
+
     def test_initial_state_is_ok(self):
         mgr = AlertStateManager()
         assert mgr.get_status("db_health", "mydb") == "ok"
 
-    def test_initial_alert_is_silent_and_visible(self):
+    def test_n2_cold_start_first_failure_is_silent(self):
         mgr = AlertStateManager()
-        transition = mgr.update("db_health", "mydb", is_healthy=False)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=False, trigger_after_failures=2,
+        )
         assert transition is None
+        assert mgr.get_status("db_health", "mydb") == "ok"
+
+    def test_n2_cold_start_second_failure_triggers(self):
+        mgr = AlertStateManager()
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=False, trigger_after_failures=2,
+        )
+        assert transition == "triggered"
         assert mgr.get_status("db_health", "mydb") == "alert"
 
-    def test_initial_alert_triggers_when_still_alert_on_next_update(self):
+    def test_n1_cold_start_first_failure_triggers_immediately(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "mydb", is_healthy=False)
-        transition = mgr.update("db_health", "mydb", is_healthy=False)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=False, trigger_after_failures=1,
+        )
         assert transition == "triggered"
+        assert mgr.get_status("db_health", "mydb") == "alert"
 
-    def test_no_transition_when_notified_alert_stays_alert(self):
+    def test_already_alert_stays_silent_on_more_failures(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "mydb", is_healthy=False)
-        mgr.update("db_health", "mydb", is_healthy=False)
-        transition = mgr.update("db_health", "mydb", is_healthy=False)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=False, trigger_after_failures=2,
+        )
         assert transition is None
 
-    def test_transition_alert_to_ok(self):
+    def test_resolved_emitted_on_healthy_after_alert(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "mydb", is_healthy=False)
-        mgr.update("db_health", "mydb", is_healthy=False)
-        transition = mgr.update("db_health", "mydb", is_healthy=True)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=True, trigger_after_failures=2,
+        )
         assert transition == "resolved"
         assert mgr.get_status("db_health", "mydb") == "ok"
 
-    def test_initial_alert_recovery_does_not_resolve_unnotified_alert(self):
+    def test_healthy_after_unnotified_failure_does_not_resolve(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "mydb", is_healthy=False)
-        transition = mgr.update("db_health", "mydb", is_healthy=True)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=2)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=True, trigger_after_failures=2,
+        )
         assert transition is None
         assert mgr.get_status("db_health", "mydb") == "ok"
 
+    def test_flap_resets_counter_no_emission(self):
+        mgr = AlertStateManager()
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=3)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=3)
+        # Healthy mid-streak resets counter
+        mgr.update("db_health", "mydb", is_healthy=True, trigger_after_failures=3)
+        # Now must take 3 more failures to fire
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=3)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=3)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=False, trigger_after_failures=3,
+        )
+        assert transition == "triggered"
+
     def test_no_transition_when_still_ok(self):
         mgr = AlertStateManager()
-        transition = mgr.update("db_health", "mydb", is_healthy=True)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=True, trigger_after_failures=2,
+        )
         assert transition is None
 
     def test_get_all_alerts(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "db1", is_healthy=False)
-        mgr.update("upstream_health", "svc1", is_healthy=False)
-        mgr.update("db_health", "db2", is_healthy=True)
+        mgr.update("db_health", "db1", is_healthy=False, trigger_after_failures=1)
+        mgr.update("upstream_health", "svc1", is_healthy=False, trigger_after_failures=1)
+        mgr.update("db_health", "db2", is_healthy=True, trigger_after_failures=1)
         alerts = mgr.get_all_alerts()
         assert len(alerts) == 2
         targets = {a["target"] for a in alerts}
@@ -195,20 +232,29 @@ class TestAlertState:
 
     def test_get_all_statuses_includes_known_ok_and_alert_states(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "db1", is_healthy=False)
-        mgr.update("db_health", "db2", is_healthy=True)
-
+        mgr.update("db_health", "db1", is_healthy=False, trigger_after_failures=1)
+        mgr.update("db_health", "db2", is_healthy=True, trigger_after_failures=1)
         statuses = mgr.get_all_statuses()
-
         status_by_target = {entry["target"]: entry["status"] for entry in statuses}
         assert status_by_target == {"db1": "alert", "db2": "ok"}
 
     def test_reset_clears_all(self):
         mgr = AlertStateManager()
-        mgr.update("db_health", "mydb", is_healthy=False)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=1)
         mgr.reset()
         assert mgr.get_status("db_health", "mydb") == "ok"
         assert mgr.get_all_alerts() == []
+
+    def test_n_lowered_mid_flight_fires_on_next_failure(self):
+        mgr = AlertStateManager()
+        # Build up to fail_count=2 under N=5
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=5)
+        mgr.update("db_health", "mydb", is_healthy=False, trigger_after_failures=5)
+        # N tightened to 3; next failure should fire (counter becomes 3)
+        transition = mgr.update(
+            "db_health", "mydb", is_healthy=False, trigger_after_failures=3,
+        )
+        assert transition == "triggered"
 
     @pytest.mark.asyncio
     async def test_persist_and_restore_alert_state(self, seeded_db):
@@ -219,8 +265,8 @@ class TestAlertState:
 
         session_factory = async_sessionmaker(seeded_db, class_=AsyncSession, expire_on_commit=False)
         mgr = AlertStateManager()
-        mgr.update("db_health", "main-db", is_healthy=False)
-        mgr.update("db_health", "main-db", is_healthy=False)
+        mgr.update("db_health", "main-db", is_healthy=False, trigger_after_failures=2)
+        mgr.update("db_health", "main-db", is_healthy=False, trigger_after_failures=2)
 
         async with session_factory() as db:
             await save_alert_state_to_db(db, mgr, "db_health", "main-db")
@@ -233,3 +279,7 @@ class TestAlertState:
         statuses = restored.get_all_statuses()
         assert statuses[0]["target"] == "main-db"
         assert statuses[0]["status"] == "alert"
+        # fail_count must round-trip
+        entry = restored.get_entry("db_health", "main-db")
+        assert entry is not None
+        assert entry["fail_count"] == 2

--- a/unibridge-service/tests/test_alerts_router.py
+++ b/unibridge-service/tests/test_alerts_router.py
@@ -1070,7 +1070,7 @@ async def test_update_rule_retarget_clears_old_rule_scoped_alert_state(
             target=state_target,
             status="alert",
             display_target="checkout (route-a)",
-            alert_notified=True,
+            fail_count=2,
         ))
         await db.commit()
 
@@ -1138,7 +1138,7 @@ async def test_delete_rule_clears_rule_scoped_alert_state(client, admin_token, s
             target=state_target,
             status="alert",
             display_target="checkout (route-a)",
-            alert_notified=True,
+            fail_count=2,
         ))
         await db.commit()
 
@@ -1149,7 +1149,7 @@ async def test_delete_rule_clears_rule_scoped_alert_state(client, admin_token, s
         status="alert",
         since="2026-05-07T00:00:00+00:00",
         display_target="checkout (route-a)",
-        alert_notified=True,
+        fail_count=2,
     )
     alerts_router.set_alert_state(state)
 
@@ -1328,8 +1328,8 @@ async def test_alert_status_no_state(client, admin_token):
 @pytest.mark.asyncio
 async def test_alert_status_with_state(client, admin_token):
     state = AlertStateManager()
-    state.update("db_health", "db-x", is_healthy=False)
-    state.update("db_health", "db-x", is_healthy=False)  # transition to active alert
+    state.update("db_health", "db-x", is_healthy=False, trigger_after_failures=2)
+    state.update("db_health", "db-x", is_healthy=False, trigger_after_failures=2)  # transition to active alert
     alerts_router.set_alert_state(state)
     try:
         resp = await client.get("/admin/alerts/status", headers=auth_header(admin_token))

--- a/unibridge-service/tests/test_alerts_router.py
+++ b/unibridge-service/tests/test_alerts_router.py
@@ -1340,3 +1340,47 @@ async def test_alert_status_with_state(client, admin_token):
         assert rows[0]["status"] == "alert"
     finally:
         alerts_router.set_alert_state(None)
+
+
+@pytest.mark.asyncio
+async def test_update_alert_settings_trigger_after_failures(client, admin_token):
+    resp = await client.put(
+        "/admin/alerts/settings",
+        json={"trigger_after_failures": 5},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["trigger_after_failures"] == 5
+
+    resp_get = await client.get(
+        "/admin/alerts/settings",
+        headers=auth_header(admin_token),
+    )
+    assert resp_get.status_code == 200
+    assert resp_get.json()["trigger_after_failures"] == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_value", [0, -1, 11, 100])
+async def test_update_alert_settings_trigger_after_failures_out_of_range(
+    client, admin_token, invalid_value,
+):
+    resp = await client.put(
+        "/admin/alerts/settings",
+        json={"trigger_after_failures": invalid_value},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_alert_settings_trigger_after_failures_rejects_null(
+    client, admin_token,
+):
+    resp = await client.put(
+        "/admin/alerts/settings",
+        json={"trigger_after_failures": None},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 422

--- a/unibridge-service/tests/test_migration_0005_n_strike.py
+++ b/unibridge-service/tests/test_migration_0005_n_strike.py
@@ -1,0 +1,97 @@
+"""Data-level verification of migration 0005 (N-strike).
+
+Seeds alert_state rows at revision 0004, upgrades to 0005, asserts fail_count
+matches spec §6 matrix, then downgrades and verifies alert_notified restoration.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+
+# alembic.ini lives at unibridge-service/alembic.ini; resolve absolutely so the
+# test is independent of pytest's working directory.
+ALEMBIC_INI = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "alembic.ini")
+)
+
+
+@pytest.fixture
+def alembic_sqlite_url():
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        # env.py uses async_engine_from_config, so the URL must use an async
+        # driver. We hand alembic the aiosqlite URL and use the equivalent
+        # sync URL for direct seeding/assertions below.
+        yield path
+    finally:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def _alembic_cfg(db_path: str) -> Config:
+    cfg = Config(ALEMBIC_INI)
+    cfg.set_main_option("sqlalchemy.url", f"sqlite+aiosqlite:///{db_path}")
+    return cfg
+
+
+def test_migration_0005_fail_count_backfill_and_downgrade(alembic_sqlite_url):
+    db_path = alembic_sqlite_url
+    cfg = _alembic_cfg(db_path)
+    sync_url = f"sqlite:///{db_path}"
+
+    # Bring schema up to revision 0004 (pre-N-strike).
+    command.upgrade(cfg, "0004_alert_owner_routing")
+
+    engine = create_engine(sync_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT OR REPLACE INTO alert_state "
+            "(alert_type, target, status, since, display_target, alert_notified, updated_at) "
+            "VALUES "
+            "('db_health', 'a', 'alert', CURRENT_TIMESTAMP, 'a', 1, CURRENT_TIMESTAMP),"
+            "('db_health', 'b', 'alert', CURRENT_TIMESTAMP, 'b', 0, CURRENT_TIMESTAMP),"
+            "('db_health', 'c', 'ok',    CURRENT_TIMESTAMP, 'c', 1, CURRENT_TIMESTAMP)"
+        ))
+
+    command.upgrade(cfg, "0005_alert_trigger_after_failures")
+
+    with engine.begin() as conn:
+        rows = {
+            row.target: row
+            for row in conn.execute(text(
+                "SELECT target, status, fail_count FROM alert_state ORDER BY target"
+            ))
+        }
+
+    assert rows["a"].status == "alert"
+    assert rows["a"].fail_count == 2
+    assert rows["b"].status == "ok"
+    assert rows["b"].fail_count == 1
+    assert rows["c"].status == "ok"
+    assert rows["c"].fail_count == 0
+
+    command.downgrade(cfg, "0004_alert_owner_routing")
+
+    with engine.begin() as conn:
+        result = {
+            row.target: row
+            for row in conn.execute(text(
+                "SELECT target, status, alert_notified FROM alert_state ORDER BY target"
+            ))
+        }
+
+    assert result["a"].status == "alert"
+    assert result["a"].alert_notified in (1, True)
+    assert result["b"].status == "ok"
+    assert result["c"].status == "ok"
+
+    engine.dispose()

--- a/unibridge-service/tests/test_migration_0005_n_strike.py
+++ b/unibridge-service/tests/test_migration_0005_n_strike.py
@@ -89,9 +89,17 @@ def test_migration_0005_fail_count_backfill_and_downgrade(alembic_sqlite_url):
             ))
         }
 
+    # 'a' (originally alert+notified) round-trips cleanly.
     assert result["a"].status == "alert"
     assert result["a"].alert_notified in (1, True)
+    # 'b' was originally (alert, alert_notified=FALSE). The upgrade
+    # intentionally collapses that into (ok, fail_count=N-1); the downgrade
+    # cannot reconstruct the original because (ok, fail_count>0) is a
+    # legitimate new-model state too. Verify the documented one-way behavior
+    # rather than a clean round-trip.
     assert result["b"].status == "ok"
+    assert result["b"].alert_notified in (1, True)
     assert result["c"].status == "ok"
+    assert result["c"].alert_notified in (1, True)
 
     engine.dispose()

--- a/unibridge-ui/src/api/client.ts
+++ b/unibridge-ui/src/api/client.ts
@@ -702,6 +702,7 @@ export interface AlertSettings {
   fallback_owner_group_id: number | null;
   route_error_threshold_pct: number;
   check_interval_seconds: number;
+  trigger_after_failures: number;
   updated_at?: string | null;
 }
 

--- a/unibridge-ui/src/locales/en.json
+++ b/unibridge-ui/src/locales/en.json
@@ -467,6 +467,8 @@
     "fallbackOwnerGroup": "Fallback Owner Group",
     "routeErrorThreshold": "Route Error Threshold (%)",
     "checkInterval": "Check Interval (seconds)",
+    "triggerAfterFailures": "Consecutive failures to trigger",
+    "triggerAfterFailuresHelp": "An alert fires only after this many consecutive failed checks (1–10).",
     "saveSettings": "Save Settings",
     "unassigned": "Unassigned",
     "addOwnerGroup": "Add Owner Group",

--- a/unibridge-ui/src/locales/ko.json
+++ b/unibridge-ui/src/locales/ko.json
@@ -467,6 +467,8 @@
     "fallbackOwnerGroup": "대체 소유자 그룹",
     "routeErrorThreshold": "라우트 에러율 임계치 (%)",
     "checkInterval": "확인 주기 (초)",
+    "triggerAfterFailures": "연속 실패 횟수",
+    "triggerAfterFailuresHelp": "이 횟수만큼 연속으로 실패해야 알람이 발송됩니다 (1~10).",
     "saveSettings": "설정 저장",
     "unassigned": "미지정",
     "addOwnerGroup": "소유자 그룹 추가",

--- a/unibridge-ui/src/pages/alerts/AlertMailChannelPanel.tsx
+++ b/unibridge-ui/src/pages/alerts/AlertMailChannelPanel.tsx
@@ -26,6 +26,7 @@ const defaultSettings: AlertSettings = {
   fallback_owner_group_id: null,
   route_error_threshold_pct: 10,
   check_interval_seconds: 60,
+  trigger_after_failures: 2,
 };
 
 const emptyChannelForm = (): AlertChannelCreate & { headerPairs: HeaderPair[] } => ({
@@ -229,6 +230,7 @@ export default function AlertMailChannelPanel() {
       fallback_owner_group_id: settingsForm.fallback_owner_group_id,
       route_error_threshold_pct: settingsForm.route_error_threshold_pct,
       check_interval_seconds: settingsForm.check_interval_seconds,
+      trigger_after_failures: settingsForm.trigger_after_failures,
     });
   }
 
@@ -347,6 +349,25 @@ export default function AlertMailChannelPanel() {
                 setSettingsDraft((prev) => ({ ...prev, check_interval_seconds: Number(e.target.value) }))
               }
             />
+          </div>
+          <div className="form-group">
+            <label htmlFor="trigger-after-failures">{t('alerts.triggerAfterFailures')}</label>
+            <input
+              id="trigger-after-failures"
+              type="number"
+              min={1}
+              max={10}
+              step={1}
+              value={settingsForm.trigger_after_failures}
+              disabled={!hasSettings || !canWrite}
+              onChange={(e) =>
+                setSettingsDraft((prev) => ({
+                  ...prev,
+                  trigger_after_failures: Number(e.target.value),
+                }))
+              }
+            />
+            <p className="form-hint">{t('alerts.triggerAfterFailuresHelp')}</p>
           </div>
         </div>
         {canWrite && (

--- a/unibridge-ui/src/test/AlertSettings.test.tsx
+++ b/unibridge-ui/src/test/AlertSettings.test.tsx
@@ -109,12 +109,14 @@ describe('AlertSettings page', () => {
       fallback_owner_group_id: null,
       route_error_threshold_pct: 10,
       check_interval_seconds: 60,
+      trigger_after_failures: 2,
     });
     mocks.updateSettings.mockResolvedValue({
       mail_channel_id: 1,
       fallback_owner_group_id: null,
       route_error_threshold_pct: 10,
       check_interval_seconds: 60,
+      trigger_after_failures: 2,
     });
     mocks.getOwnerGroups.mockResolvedValue([]);
     mocks.createOwnerGroup.mockResolvedValue({
@@ -527,6 +529,7 @@ describe('AlertSettings page (alerts.read only)', () => {
       fallback_owner_group_id: 2,
       route_error_threshold_pct: 10,
       check_interval_seconds: 60,
+      trigger_after_failures: 2,
     });
     mocks.getOwnerGroups.mockResolvedValue([
       { id: 2, name: 'orders-team', emails: ['orders@example.com'], enabled: true },

--- a/unibridge-ui/src/test/AlertSettings.test.tsx
+++ b/unibridge-ui/src/test/AlertSettings.test.tsx
@@ -159,6 +159,24 @@ describe('AlertSettings page', () => {
     expect(mocks.updateSettings.mock.calls[0][0]).toMatchObject({ mail_channel_id: 1 });
   });
 
+  it('saves updated trigger_after_failures via settings form', async () => {
+    renderWithProviders(<AlertSettings />);
+    const failuresInput = await screen.findByLabelText(
+      /연속 실패 횟수|Consecutive failures/i,
+    );
+    await waitFor(() => expect(failuresInput).toHaveValue(2));
+
+    await userEvent.clear(failuresInput);
+    await userEvent.type(failuresInput, '5');
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save Settings$|^설정 저장$/i }));
+
+    await waitFor(() => expect(mocks.updateSettings).toHaveBeenCalled());
+    expect(mocks.updateSettings.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ trigger_after_failures: 5 }),
+    );
+  });
+
   it('disables alert settings save before settings have loaded', async () => {
     mocks.getSettings.mockReturnValue(new Promise(() => undefined));
     renderWithProviders(<AlertSettings />);


### PR DESCRIPTION
## Summary

알림(Alert) 트리거 조건의 "연속 실패 횟수"(N-strike)를 UI에서 설정할 수 있도록 만듭니다. 이전에는 콜드스타트 vs 평상시 동작이 비대칭(2회 vs 1회 연속 실패)으로 코드에 박혀 있었는데, 단일 설정값 `trigger_after_failures`로 통일하고 메일 채널 설정 패널에서 1~10 범위로 조정 가능하게 합니다.

**기본값:** 2 (현재 콜드스타트 동작과 동일 → 기존 운영 동작 그대로 유지)

## 변경 사항

### 데이터 모델
- `AlertSettings.trigger_after_failures` 컬럼 추가 (Integer, default 2, CHECK BETWEEN 1 AND 10)
- `AlertState.alert_notified` (Boolean) → `fail_count` (Integer) 교체

### 상태 머신 재작성 (`AlertStateManager`)
- 매 사이클 결과를 `fail_count`에 누적 → `fail_count >= N`일 때만 status를 `alert`로 전이 + `triggered` 발송
- healthy 관측 시 카운터 즉시 리셋 (flap 흡수), 이전이 alert였으면 `resolved` 발송
- 카운터는 N에서 cap (장기 장애에서도 무한 증가 방지)

### Alembic 0005 마이그레이션
- 컬럼 추가/제거 + 데이터 백필
- 기존 `(status=alert, alert_notified=TRUE)` → `fail_count = N`
- 기존 `(status=alert, alert_notified=FALSE)` → `status=ok, fail_count = N-1` (한 번 더 실패해야 발송 = 콜드스타트 안전장치 보존)
- down 마이그레이션도 양방향 round-trip 검증

### 체커 배선
- `_get_trigger_after_failures()` 헬퍼 (DB에서 매 사이클 N 재로딩, 1~10 clamp)
- `run_single_check` 및 `_evaluate_route_error_rule`에 N 전달
- 4개 헬스체크 경로(db/upstream/error_rate/route_error_rate) + active-alert sweep 모두 N 적용

### UI
- `AlertMailChannelPanel` 설정 폼에 "연속 실패 횟수" number input 추가 (min=1, max=10)
- i18n 키 2개 (ko/en)
- `AlertSettings` TS 타입 업데이트

### 영향
- N=1 설정 시 즉시 발송(콜드스타트 차이 없음)
- N=2 (기본) 설정 시 기존 콜드스타트 동작과 동일, 평상시 첫 장애 감지가 60초→120초로 한 사이클 늦어짐(설정으로 조절 가능)
- `resolved`에는 N 적용 안 함 (1회 정상으로 즉시 복구 알림)

## 테스트

- 백엔드 pytest: **962 passed**
- UI vitest: **252 passed**
- 마이그레이션 up/down/up round-trip 깨끗
- UI build 성공

### 신규/변경 테스트
- `tests/test_alerts.py::TestAlertState` — 14개 N-strike 시나리오 (N=1/2/3/5, flap, resolved 게이트, persist/restore의 fail_count 라운드트립)
- `tests/test_migration_0005_n_strike.py` — `(status, alert_notified)` 매트릭스 시드 후 upgrade → 매트릭스 검증 → downgrade → 복원 검증
- `tests/test_alert_checker.py` — N=3 시나리오 추가 (2회 미발송, 3회째 발송)
- `tests/test_alerts_router.py` — API 라운드트립, 0/-1/11/100 거부, null 거부
- `unibridge-ui/src/test/AlertSettings.test.tsx` — 입력 변경 후 submit payload에 `trigger_after_failures` 포함 확인

## 스펙/플랜

- 설계: `docs/superpowers/specs/2026-05-11-alert-n-strike-design.md` (gitignored 디렉토리)
- 구현 플랜: `docs/superpowers/plans/2026-05-11-alert-n-strike.md`

## Scope Out (향후 작업)

- 룰별 N override
- 발송 throttling / re-notify
- 상태 API에서 `fail_count` 노출
