### PR TITLE
[codex] Improve UI UX responsiveness

### DIFF
--- a/unibridge-ui/src/App.tsx
+++ b/unibridge-ui/src/App.tsx
@@ -30,9 +30,10 @@ const NasConnections = lazy(() => import('./pages/NasConnections'));
 const NasBrowser = lazy(() => import('./pages/NasBrowser'));
 
 export function ProtectedRoute({ permission, children }: { permission: string | string[]; children: React.ReactNode }) {
+  const { t } = useTranslation();
   const { permissions: perms, loaded } = usePermissions();
   if (!loaded) {
-    return null;
+    return <PageStatus>{t('common.loading')}</PageStatus>;
   }
   if (!hasNavPermission(permission, perms)) {
     return <Navigate to="/" replace />;
@@ -40,13 +41,18 @@ export function ProtectedRoute({ permission, children }: { permission: string | 
   return <>{children}</>;
 }
 
-function RouteFallback() {
-  const { t } = useTranslation();
+function PageStatus({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ padding: 24, color: 'var(--text-secondary)', fontSize: 14 }}>
-      {t('common.loading')}
+    <div className="page-status" role="status" aria-live="polite">
+      <span className="page-status__spinner" aria-hidden="true" />
+      <span>{children}</span>
     </div>
   );
+}
+
+function RouteFallback() {
+  const { t } = useTranslation();
+  return <PageStatus>{t('common.loading')}</PageStatus>;
 }
 
 // Landing page: dashboard for users who can see it, otherwise their first
@@ -54,12 +60,12 @@ function RouteFallback() {
 function Home() {
   const { t } = useTranslation();
   const { permissions, loaded } = usePermissions();
-  if (!loaded) return null;
+  if (!loaded) return <PageStatus>{t('common.loading')}</PageStatus>;
   if (permissions.includes('dashboard.read')) return <Dashboard />;
   const target = firstAccessiblePath(permissions);
   if (target) return <Navigate to={target} replace />;
   return (
-    <div style={{ padding: 24, color: 'var(--text-secondary)', fontSize: 14 }}>
+    <div className="page-status page-status--empty">
       {t('common.noAccess')}
     </div>
   );

--- a/unibridge-ui/src/components/DataTablePageHeader.tsx
+++ b/unibridge-ui/src/components/DataTablePageHeader.tsx
@@ -19,16 +19,20 @@ function DataTablePageHeader({
 }: DataTablePageHeaderProps) {
   const showAdd = Boolean(canAdd && onAdd && addLabel);
   return (
-    <div className="page-header">
+    <div className="page-header page-header--with-actions">
       <div>
         <h1>{title}</h1>
         {subtitle && <p className="page-subtitle">{subtitle}</p>}
       </div>
-      {extra}
-      {showAdd && (
-        <button className="btn btn-primary" onClick={onAdd}>
-          {addLabel}
-        </button>
+      {(extra || showAdd) && (
+        <div className="page-header__actions">
+          {extra}
+          {showAdd && (
+            <button className="btn btn-primary" onClick={onAdd}>
+              {addLabel}
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/unibridge-ui/src/components/Layout.css
+++ b/unibridge-ui/src/components/Layout.css
@@ -3,6 +3,11 @@
   min-height: 100vh;
 }
 
+.mobile-topbar,
+.nav-scrim {
+  display: none;
+}
+
 /* ── Sidebar ── */
 
 .sidebar {
@@ -292,4 +297,124 @@
   background: color-mix(in srgb, var(--accent-red) 8%, transparent);
   color: var(--accent-red);
   font-size: 13px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    display: block;
+  }
+
+  .mobile-topbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 90;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    height: 56px;
+    padding: 0 14px;
+    background: var(--bg-root);
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .mobile-nav-toggle,
+  .nav-scrim {
+    border: 0;
+    padding: 0;
+    background: transparent;
+  }
+
+  .mobile-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+  }
+
+  .mobile-nav-toggle:hover {
+    border-color: var(--border-hover);
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  .mobile-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  .mobile-brand::after {
+    content: "UniBridge";
+    font-size: 14px;
+  }
+
+  .mobile-username {
+    margin-left: auto;
+    min-width: 0;
+    max-width: 42vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  .sidebar {
+    width: min(280px, 84vw);
+    min-width: 0;
+    transform: translateX(-100%);
+    transition: transform 0.18s ease;
+    box-shadow: var(--shadow-lg);
+    z-index: 120;
+  }
+
+  .layout--nav-open .sidebar {
+    transform: translateX(0);
+  }
+
+  .nav-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 110;
+    display: block;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.18s ease;
+  }
+
+  .layout--nav-open .nav-scrim {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .main-content {
+    margin-left: 0;
+    padding: 76px 18px 28px;
+  }
+
+  .sidebar-header {
+    padding-top: 18px;
+  }
+}
+
+@media (max-width: 560px) {
+  .main-content {
+    padding: 72px 12px 24px;
+  }
+
+  .permission-error-banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }

--- a/unibridge-ui/src/components/Layout.tsx
+++ b/unibridge-ui/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import { useState, type ReactNode } from 'react';
-import { NavLink, Link } from 'react-router-dom';
+import { useEffect, useState, type ReactNode } from 'react';
+import { NavLink, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { getCurrentUser } from '../api/client';
@@ -16,7 +16,9 @@ interface LayoutProps {
 function Layout({ children }: LayoutProps) {
   const { t } = useTranslation();
   const { username, logout } = useAuth();
+  const location = useLocation();
   const [showSettings, setShowSettings] = useState(false);
+  const [navOpenPath, setNavOpenPath] = useState<string | null>(null);
 
   const permissionsQuery = useQuery({
     queryKey: ['current-user'],
@@ -29,10 +31,44 @@ function Layout({ children }: LayoutProps) {
 
   const hasPermission = (perm: Parameters<typeof hasNavPermission>[0]) =>
     hasNavPermission(perm, userPermissions);
+  const isNavOpen = navOpenPath === location.pathname;
+
+  useEffect(() => {
+    if (!isNavOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isNavOpen]);
 
   return (
-    <div className="layout">
-      <aside className="sidebar">
+    <div className={`layout ${isNavOpen ? 'layout--nav-open' : ''}`}>
+      <header className="mobile-topbar">
+        <button
+          type="button"
+          className="mobile-nav-toggle"
+          aria-label={t('common.openNavigation')}
+          aria-controls="app-sidebar"
+          aria-expanded={isNavOpen}
+          onClick={() => setNavOpenPath(location.pathname)}
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M3 5h14M3 10h14M3 15h14" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+          </svg>
+        </button>
+        <Link to="/" className="mobile-brand" aria-label="UniBridge">
+          <span className="sidebar-logo-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M3 5h10M3 8h10M3 11h7" stroke="var(--text-inverse)" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </span>
+        </Link>
+        {username && <span className="mobile-username">{username}</span>}
+      </header>
+      <aside className="sidebar" id="app-sidebar">
         <div className="sidebar-header">
           <Link to="/" className="sidebar-logo">
             <div className="sidebar-logo-icon">
@@ -53,6 +89,7 @@ function Layout({ children }: LayoutProps) {
                 <NavLink
                   to={item.to}
                   end={item.to === '/'}
+                  onClick={() => setNavOpenPath(null)}
                   className={({ isActive }) =>
                     `nav-link ${isActive ? 'nav-link--active' : ''}`
                   }
@@ -201,6 +238,12 @@ function Layout({ children }: LayoutProps) {
           <span className="sidebar-version">Query Service v1.0</span>
         </div>
       </aside>
+      <button
+        type="button"
+        className="nav-scrim"
+        aria-label={t('common.closeNavigation')}
+        onClick={() => setNavOpenPath(null)}
+      />
       <main className="main-content">
         <PermissionProvider permissions={userPermissions} loaded={permissionsLoaded}>
           {permissionsQuery.isError && (

--- a/unibridge-ui/src/components/TimeRangeSelector.css
+++ b/unibridge-ui/src/components/TimeRangeSelector.css
@@ -39,7 +39,7 @@
   padding: 12px;
   border-radius: 8px;
   background: var(--bg-secondary, #1e1e1e);
-  border: 1px solid var(--border-color, #333);
+  border: 1px solid var(--border-default, #333);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 

--- a/unibridge-ui/src/locales/en.json
+++ b/unibridge-ui/src/locales/en.json
@@ -50,7 +50,9 @@
     "type": "Type",
     "status": "Status",
     "errorOccurred": "An error occurred",
-    "noAccess": "No accessible pages. Contact an administrator."
+    "noAccess": "No accessible pages. Contact an administrator.",
+    "openNavigation": "Open navigation",
+    "closeNavigation": "Close navigation"
   },
   "settings": {
     "title": "Settings",

--- a/unibridge-ui/src/locales/ko.json
+++ b/unibridge-ui/src/locales/ko.json
@@ -50,7 +50,9 @@
     "type": "유형",
     "status": "상태",
     "errorOccurred": "오류가 발생했습니다",
-    "noAccess": "접근 가능한 페이지가 없습니다. 관리자에게 문의하세요."
+    "noAccess": "접근 가능한 페이지가 없습니다. 관리자에게 문의하세요.",
+    "openNavigation": "내비게이션 열기",
+    "closeNavigation": "내비게이션 닫기"
   },
   "settings": {
     "title": "설정",

--- a/unibridge-ui/src/pages/GatewayMonitoring.css
+++ b/unibridge-ui/src/pages/GatewayMonitoring.css
@@ -153,7 +153,7 @@
 .api-key-filter__select {
   background: var(--bg-secondary);
   color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-default);
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 13px;
@@ -163,4 +163,23 @@
 .api-key-filter__select:focus {
   outline: none;
   border-color: var(--accent-blue);
+}
+
+@media (max-width: 720px) {
+  .page-header__filters {
+    width: 100%;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .api-key-filter {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .api-key-filter__select {
+    width: 100%;
+  }
 }

--- a/unibridge-ui/src/pages/NasBrowser.css
+++ b/unibridge-ui/src/pages/NasBrowser.css
@@ -96,7 +96,7 @@
 
 .nas-metadata-table td {
   padding: 6px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-default);
   font-size: 13px;
 }
 

--- a/unibridge-ui/src/pages/S3Browser.css
+++ b/unibridge-ui/src/pages/S3Browser.css
@@ -119,7 +119,7 @@
 
 .s3-metadata-table td {
   padding: 6px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-default);
   font-size: 13px;
 }
 

--- a/unibridge-ui/src/styles/shared.css
+++ b/unibridge-ui/src/styles/shared.css
@@ -264,6 +264,27 @@
   white-space: nowrap;
 }
 
+.page-header--with-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.page-header--with-actions > div:first-child {
+  min-width: 0;
+}
+
+.page-header__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
 /* ── Badges ── */
 
 .badge {
@@ -476,10 +497,53 @@
 /* ── States ── */
 
 .loading-message {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
   padding: 48px;
   color: var(--text-tertiary);
   font-size: 14px;
+}
+
+.loading-message::before,
+.page-status__spinner {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-hover);
+  border-top-color: var(--text-secondary);
+  border-radius: 50%;
+  animation: loading-spin 0.8s linear infinite;
+  flex: 0 0 auto;
+}
+
+.page-status {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 32px 20px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-primary);
+  color: var(--text-tertiary);
+  font-size: 14px;
+}
+
+.page-status--empty {
+  min-height: 180px;
+}
+
+.page-status--empty .page-status__spinner {
+  display: none;
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .error-banner {
@@ -506,4 +570,114 @@
 
 .empty-state p {
   font-size: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-message::before,
+  .page-status__spinner {
+    animation: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .alert-settings .page-header.page-header,
+  .alert-status .page-header.page-header,
+  .api-keys .page-header.page-header,
+  .connections .page-header.page-header,
+  .gateway-monitoring .page-header.page-header,
+  .gateway-routes .page-header.page-header,
+  .gateway-upstreams .page-header.page-header,
+  .llm-monitoring .page-header.page-header,
+  .roles-page .page-header.page-header,
+  .users-page .page-header.page-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+
+  .page-header--with-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+
+  .page-header__actions {
+    justify-content: flex-start;
+  }
+
+  .page-header__filters {
+    width: 100%;
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .page-header__actions .btn,
+  .page-header--with-actions > .btn {
+    width: 100%;
+  }
+
+  .page-header h1 {
+    font-size: 21px;
+  }
+
+  .page-subtitle {
+    font-size: 12px;
+  }
+
+  .table-container {
+    border-radius: var(--radius-md);
+  }
+
+  .data-table {
+    font-size: 12px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 9px 10px;
+  }
+
+  .loading-message {
+    padding: 28px 12px;
+  }
+
+  .page-status {
+    min-height: 160px;
+    padding: 24px 14px;
+  }
+
+  .empty-state {
+    padding: 40px 16px;
+  }
+
+  .empty-state h3 {
+    font-size: 16px;
+  }
+
+  .modal {
+    width: calc(100vw - 24px);
+    max-width: calc(100vw - 24px);
+    max-height: calc(100vh - 24px);
+  }
+
+  .modal-header {
+    padding: 16px 18px 0;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 18px;
+  }
+
+  .modal-actions {
+    padding: 12px 18px 18px;
+    flex-wrap: wrap;
+  }
+
+  .modal-actions .btn {
+    flex: 1 1 140px;
+  }
 }

--- a/unibridge-ui/src/test/App.test.tsx
+++ b/unibridge-ui/src/test/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
@@ -144,6 +144,30 @@ describe('App', () => {
 
     // Sidebar title
     expect(screen.getByText('UniBridge')).toBeInTheDocument();
+  });
+
+  it('opens and closes the mobile navigation drawer', async () => {
+    renderWithProviders(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Connections')).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByRole('button', { name: 'Open navigation', hidden: true });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('.layout')).not.toHaveClass('layout--nav-open');
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(document.querySelector('.layout')).toHaveClass('layout--nav-open');
+
+    const scrim = document.querySelector<HTMLButtonElement>('.nav-scrim');
+    expect(scrim).toHaveAttribute('aria-label', 'Close navigation');
+    fireEvent.click(scrim!);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('.layout')).not.toHaveClass('layout--nav-open');
   });
 
   it('renders the sidebar title "UniBridge"', async () => {


### PR DESCRIPTION
## What changed
- Added a mobile topbar and drawer navigation for small screens.
- Replaced blank permission/route loading states with visible page status UI.
- Improved shared responsive spacing for page headers, tables, modals, and forms.
- Fixed undefined border token usage in monitoring, S3, NAS, and time-range UI styles.
- Added coverage for opening and closing the mobile navigation drawer.

## Why
The current UI relied on a fixed sidebar and sparse loading states, which made small-screen navigation and route transitions feel unclear. These changes improve navigation access, state feedback, and responsive layout consistency across common screens.

## Validation
- `npm --prefix unibridge-ui test`
- `npm --prefix unibridge-ui run build`
- `npm --prefix unibridge-ui run lint` (existing warnings remain in S3/NAS browser effects and QueryTemplates memo dependencies)