### PR TITLE
feat: SQLite→Postgres meta-store migration + fix Alembic version_num width

### DIFF
--- a/docs/blue-green-deploy.md
+++ b/docs/blue-green-deploy.md
@@ -92,6 +92,26 @@ META_DB_URL=postgresql+asyncpg://unibridge:<password>@<host>:5432/unibridge
 unset). To override anyway — single-color use, or you accept the risk — set
 `ALLOW_SQLITE_BLUEGREEN=true`.
 
+### Migrating existing SQLite data to Postgres
+
+If you already run a single-stack deployment on the default SQLite meta store,
+copy that data into the new Postgres database before the first blue-green
+deploy. From `unibridge-service/` (with the **same `ENCRYPTION_KEY`** as the
+source — encrypted credentials are copied verbatim and stay valid only under
+the same key):
+
+```bash
+python -m scripts.migrate_sqlite_to_postgres \
+  --source sqlite+aiosqlite:///data/meta.db \
+  --target postgresql+asyncpg://unibridge:<password>@<host>:5432/unibridge
+```
+
+It creates the schema on the empty Postgres target, copies every table, and
+resets sequences so the live app does not collide with copied primary keys. Use
+`--dry-run` to preview row counts; it refuses a non-empty target unless
+`--truncate` is given. After it succeeds, point `META_DB_URL` at the Postgres
+URL and deploy.
+
 ## Existing Volume Names
 
 The split Compose files use explicit volume names so existing single-stack

--- a/docs/blue-green-deploy.md
+++ b/docs/blue-green-deploy.md
@@ -106,6 +106,11 @@ From `unibridge-service/` (with the **same `ENCRYPTION_KEY`** as the source —
 encrypted credentials are copied verbatim and stay valid only under the same
 key):
 
+Make sure the SQLite source has already been upgraded by the current app (or by
+running `alembic upgrade head`) before copying. The migration script verifies
+that the source `alembic_version` matches the current code's head and stops if
+it does not.
+
 ```bash
 python -m scripts.migrate_sqlite_to_postgres \
   --source sqlite+aiosqlite:///data/meta.db \

--- a/docs/blue-green-deploy.md
+++ b/docs/blue-green-deploy.md
@@ -96,9 +96,15 @@ unset). To override anyway — single-color use, or you accept the risk — set
 
 If you already run a single-stack deployment on the default SQLite meta store,
 copy that data into the new Postgres database before the first blue-green
-deploy. From `unibridge-service/` (with the **same `ENCRYPTION_KEY`** as the
-source — encrypted credentials are copied verbatim and stay valid only under
-the same key):
+deploy.
+
+> **Stop the old stack (or quiesce writes) first.** This is a one-shot snapshot
+> copy, not a live replica — any row written to SQLite after the copy begins is
+> lost. Bring the single-stack deployment down, run the migration, then cut over.
+
+From `unibridge-service/` (with the **same `ENCRYPTION_KEY`** as the source —
+encrypted credentials are copied verbatim and stay valid only under the same
+key):
 
 ```bash
 python -m scripts.migrate_sqlite_to_postgres \

--- a/unibridge-service/alembic/env.py
+++ b/unibridge-service/alembic/env.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import sys
 
 from alembic import context
-from sqlalchemy import pool
+from alembic.ddl.impl import DefaultImpl
+from sqlalchemy import String, pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -21,6 +22,25 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
+
+# Our revision slugs (e.g. "0013_resource_owner_alerts_enabled") run to 34 chars,
+# longer than Alembic's default VARCHAR(32) version_num column. SQLite ignores
+# the length so it never bit, but Postgres/MSSQL reject the overflow at boot.
+# Alembic 1.17 hard-codes String(32) in DefaultImpl.version_table_impl and the
+# `version_table_column_type` configure option does not exist, so widen the
+# column by overriding the hook. Idempotent: existing version tables are reused
+# as-is (Alembic only consults this when creating the table).
+_VERSION_NUM_LEN = 255
+_orig_version_table_impl = DefaultImpl.version_table_impl
+
+
+def _widened_version_table_impl(self, **kw):
+    table = _orig_version_table_impl(self, **kw)
+    table.c.version_num.type = String(_VERSION_NUM_LEN)
+    return table
+
+
+DefaultImpl.version_table_impl = _widened_version_table_impl
 
 if (
     os.environ.get("META_DB_URL")

--- a/unibridge-service/scripts/migrate_sqlite_to_postgres.py
+++ b/unibridge-service/scripts/migrate_sqlite_to_postgres.py
@@ -21,6 +21,11 @@ What it does
 3. Resets each table's identity/serial sequence to ``max(id)`` so the next
    INSERT in the live app does not collide with a copied primary key.
 
+Before copying, the source SQLite DB must already be upgraded to the current
+Alembic head. The script checks ``alembic_version`` and stops if the source is
+missing migrations, because copying through the current ORM model would bypass
+Alembic's historical data-fix steps.
+
 Encrypted columns (``*_encrypted``) are copied verbatim — they stay valid as
 long as the target deployment uses the **same ``ENCRYPTION_KEY``** as the
 source. Verify this before cutting over, or the app cannot decrypt credentials.
@@ -49,6 +54,9 @@ Caveats
 - **Stop the old app (or quiesce writes) first.** This is a one-shot snapshot
   copy, not a live replica — any row written to SQLite after the copy starts is
   lost. Bring the single-stack deployment down before running, then cut over.
+- **Upgrade the source SQLite DB first.** Run the current app or
+  ``alembic upgrade head`` against the SQLite meta DB before copying. The script
+  refuses a source whose ``alembic_version`` is not the current head.
 - **Same ``ENCRYPTION_KEY``** on the target deployment, or stored credentials
   cannot be decrypted (encrypted columns are copied as-is).
 - Re-running is safe: a non-empty target is refused unless ``--truncate`` wipes
@@ -102,6 +110,28 @@ async def _table_names(engine: AsyncEngine) -> set[str]:
     async with engine.connect() as conn:
         return await conn.run_sync(
             lambda sync_conn: set(inspect(sync_conn).get_table_names())
+        )
+
+
+async def _ensure_source_at_head(engine: AsyncEngine, table_names: set[str]) -> None:
+    if "alembic_version" not in table_names:
+        raise SystemExit(
+            "source has no alembic_version table. Run the current app or "
+            "`alembic upgrade head` against the SQLite meta DB before copying."
+        )
+
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(text("SELECT version_num FROM alembic_version"))
+        ).scalars().all()
+
+    if rows != [ALEMBIC_HEAD_REVISION]:
+        current = ", ".join(rows) if rows else "<empty>"
+        raise SystemExit(
+            "source SQLite DB is not at Alembic head "
+            f"(current={current}, expected={ALEMBIC_HEAD_REVISION}). "
+            "Run the current app or `alembic upgrade head` against the SQLite "
+            "meta DB before copying."
         )
 
 
@@ -201,6 +231,7 @@ async def migrate(source: str, target: str, batch_size: int, truncate: bool, dry
         src_tables = await _table_names(src_engine)
         if not src_tables - {"alembic_version"}:
             raise SystemExit(f"source has no data tables: {source}")
+        await _ensure_source_at_head(src_engine, src_tables)
 
         await _ensure_target_schema(tgt_engine)
 

--- a/unibridge-service/scripts/migrate_sqlite_to_postgres.py
+++ b/unibridge-service/scripts/migrate_sqlite_to_postgres.py
@@ -1,0 +1,255 @@
+"""One-off migration: copy the meta store from SQLite to PostgreSQL.
+
+Context
+-------
+The meta store defaults to a file-based SQLite DB (``data/meta.db``). Blue-green
+deployment (``scripts/deploy-bluegreen.sh``) requires a *networked* meta store
+because two app containers run side-by-side and SQLite cannot be safely written
+by two processes at once. This script moves an existing SQLite meta store into a
+PostgreSQL database so the cutover keeps all registered connections, API keys,
+roles, audit logs, etc.
+
+What it does
+------------
+1. Creates the schema on the (empty) Postgres target from the current ORM models
+   and stamps ``alembic_version`` to head — exactly how the app bootstraps a
+   fresh DB. (Skipped if the target already has the schema.)
+2. Copies every table in FK-dependency order, streaming in batches. Values pass
+   through the SQLAlchemy column types, so ``UtcDateTime`` timestamps are read
+   back as UTC-aware and re-stored as ``timestamptz`` correctly, and booleans
+   convert from SQLite 0/1 to real Postgres booleans.
+3. Resets each table's identity/serial sequence to ``max(id)`` so the next
+   INSERT in the live app does not collide with a copied primary key.
+
+Encrypted columns (``*_encrypted``) are copied verbatim — they stay valid as
+long as the target deployment uses the **same ``ENCRYPTION_KEY``** as the
+source. Verify this before cutting over, or the app cannot decrypt credentials.
+
+Usage
+-----
+Run from the ``unibridge-service`` directory::
+
+    # source defaults to settings.META_DB_URL when it is SQLite
+    python -m scripts.migrate_sqlite_to_postgres \
+        --target postgresql+asyncpg://unibridge:PASS@db:5432/unibridge
+
+    # explicit source, wipe a non-empty target first, preview only
+    python -m scripts.migrate_sqlite_to_postgres \
+        --source sqlite+aiosqlite:///data/meta.db \
+        --target postgresql+asyncpg://unibridge:PASS@db:5432/unibridge \
+        --truncate --dry-run
+
+The target may also be supplied via the ``TARGET_META_DB_URL`` env var. The
+script refuses to write into a target that already contains data unless
+``--truncate`` is given, so a re-run does not duplicate or collide. After a
+successful run, point ``META_DB_URL`` at the Postgres URL and deploy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+from sqlalchemy import func, inspect, select, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from app.config import settings
+from app.database import ALEMBIC_HEAD_REVISION
+from app.models import Base
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("migrate_sqlite_to_postgres")
+
+# Tables in FK-dependency order (parents first). Reverse for deletes.
+TABLES = list(Base.metadata.sorted_tables)
+
+
+def _normalize_source(url: str) -> str:
+    """Coerce a SQLite URL to the async ``aiosqlite`` driver."""
+    parsed = make_url(url)
+    if not parsed.drivername.startswith("sqlite"):
+        raise SystemExit(f"--source must be a SQLite URL, got: {parsed.drivername}")
+    if parsed.drivername == "sqlite":
+        parsed = parsed.set(drivername="sqlite+aiosqlite")
+    return parsed.render_as_string(hide_password=False)
+
+
+def _normalize_target(url: str) -> str:
+    """Coerce a Postgres URL to the async ``asyncpg`` driver."""
+    parsed = make_url(url)
+    if not parsed.get_backend_name().startswith("postgresql"):
+        raise SystemExit(f"--target must be a PostgreSQL URL, got: {parsed.drivername}")
+    if parsed.drivername in ("postgresql", "postgres"):
+        parsed = parsed.set(drivername="postgresql+asyncpg")
+    return parsed.render_as_string(hide_password=False)
+
+
+async def _table_names(engine: AsyncEngine) -> set[str]:
+    async with engine.connect() as conn:
+        return await conn.run_sync(
+            lambda sync_conn: set(inspect(sync_conn).get_table_names())
+        )
+
+
+async def _ensure_target_schema(engine: AsyncEngine) -> None:
+    """Create the schema + stamp alembic head if the target is empty.
+
+    Mirrors the in-memory bootstrap path in ``app.database`` so the app will
+    not try to re-run migrations against an already-populated schema.
+    """
+    existing = await _table_names(engine)
+    if existing - {"alembic_version"}:
+        log.info("target already has schema (%d tables) — skipping create_all", len(existing))
+        return
+
+    log.info("creating schema on target from ORM models")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        # NB: revision slugs in alembic/versions/ run up to 34 chars, longer than
+        # Alembic's default VARCHAR(32) version_num. SQLite ignores VARCHAR length
+        # so it never bit there, but Postgres rejects the overflow — widen it here.
+        await conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS alembic_version ("
+                "version_num VARCHAR(255) NOT NULL, "
+                "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
+            )
+        )
+        await conn.execute(text("DELETE FROM alembic_version"))
+        await conn.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:rev)"),
+            {"rev": ALEMBIC_HEAD_REVISION},
+        )
+    log.info("schema created, stamped alembic_version=%s", ALEMBIC_HEAD_REVISION)
+
+
+async def _target_row_counts(engine: AsyncEngine) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    async with engine.connect() as conn:
+        for table in TABLES:
+            total = await conn.scalar(select(func.count()).select_from(table))
+            if total:
+                counts[table.name] = total
+    return counts
+
+
+async def _truncate_target(engine: AsyncEngine) -> None:
+    async with engine.begin() as conn:
+        for table in reversed(TABLES):
+            await conn.execute(table.delete())
+    log.info("truncated %d target tables", len(TABLES))
+
+
+async def _copy_table(
+    src: AsyncEngine, tgt: AsyncEngine, table, batch_size: int, dry_run: bool
+) -> int:
+    copied = 0
+    insert_stmt = table.insert()
+    async with src.connect() as src_conn:
+        result = await src_conn.stream(table.select())
+        async with tgt.begin() as tgt_conn:
+            async for chunk in result.partitions(batch_size):
+                rows = [dict(row._mapping) for row in chunk]
+                if not rows:
+                    continue
+                copied += len(rows)
+                if not dry_run:
+                    await tgt_conn.execute(insert_stmt, rows)
+    return copied
+
+
+async def _reset_sequences(engine: AsyncEngine) -> None:
+    """Advance each serial/identity sequence past the largest copied PK."""
+    async with engine.begin() as conn:
+        for table in TABLES:
+            pk_cols = [c for c in table.primary_key.columns if c.autoincrement is not False]
+            for col in pk_cols:
+                seq = await conn.scalar(
+                    text("SELECT pg_get_serial_sequence(:t, :c)"),
+                    {"t": table.name, "c": col.name},
+                )
+                if not seq:
+                    continue
+                max_id = await conn.scalar(select(func.max(col)))
+                if max_id is None:
+                    continue
+                await conn.execute(
+                    text("SELECT setval(:seq, :val, true)"),
+                    {"seq": seq, "val": int(max_id)},
+                )
+                log.info("  sequence %s -> %s", seq, max_id)
+
+
+async def migrate(source: str, target: str, batch_size: int, truncate: bool, dry_run: bool) -> None:
+    src_engine = create_async_engine(source)
+    tgt_engine = create_async_engine(target)
+    try:
+        src_tables = await _table_names(src_engine)
+        if not src_tables - {"alembic_version"}:
+            raise SystemExit(f"source has no data tables: {source}")
+
+        await _ensure_target_schema(tgt_engine)
+
+        existing = await _target_row_counts(tgt_engine)
+        if existing and not truncate:
+            summary = ", ".join(f"{t}={n}" for t, n in existing.items())
+            raise SystemExit(
+                f"target is not empty ({summary}). Re-run with --truncate to overwrite."
+            )
+        if existing and truncate and not dry_run:
+            await _truncate_target(tgt_engine)
+
+        log.info("%scopying %d tables (batch=%d)", "[dry-run] " if dry_run else "", len(TABLES), batch_size)
+        grand_total = 0
+        for table in TABLES:
+            if table.name not in src_tables:
+                log.info("  %-22s skipped (absent in source)", table.name)
+                continue
+            n = await _copy_table(src_engine, tgt_engine, table, batch_size, dry_run)
+            grand_total += n
+            log.info("  %-22s %d rows", table.name, n)
+
+        if not dry_run:
+            log.info("resetting Postgres sequences")
+            await _reset_sequences(tgt_engine)
+
+        log.info("%sdone — %d rows total", "[dry-run] " if dry_run else "", grand_total)
+    finally:
+        await src_engine.dispose()
+        await tgt_engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Copy the meta store from SQLite to PostgreSQL.")
+    parser.add_argument(
+        "--source",
+        default=settings.META_DB_URL,
+        help="SQLite source URL (default: settings.META_DB_URL)",
+    )
+    parser.add_argument(
+        "--target",
+        default=os.environ.get("TARGET_META_DB_URL"),
+        help="PostgreSQL target URL (default: $TARGET_META_DB_URL)",
+    )
+    parser.add_argument("--batch-size", type=int, default=1000)
+    parser.add_argument("--truncate", action="store_true", help="wipe target tables before copying")
+    parser.add_argument("--dry-run", action="store_true", help="report row counts without writing")
+    args = parser.parse_args()
+
+    if not args.target:
+        parser.error("a Postgres target is required (--target or $TARGET_META_DB_URL)")
+
+    source = _normalize_source(args.source)
+    target = _normalize_target(args.target)
+    log.info("source: %s", make_url(source).render_as_string(hide_password=True))
+    log.info("target: %s", make_url(target).render_as_string(hide_password=True))
+
+    asyncio.run(migrate(source, target, args.batch_size, args.truncate, args.dry_run))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/unibridge-service/scripts/migrate_sqlite_to_postgres.py
+++ b/unibridge-service/scripts/migrate_sqlite_to_postgres.py
@@ -43,6 +43,16 @@ The target may also be supplied via the ``TARGET_META_DB_URL`` env var. The
 script refuses to write into a target that already contains data unless
 ``--truncate`` is given, so a re-run does not duplicate or collide. After a
 successful run, point ``META_DB_URL`` at the Postgres URL and deploy.
+
+Caveats
+-------
+- **Stop the old app (or quiesce writes) first.** This is a one-shot snapshot
+  copy, not a live replica — any row written to SQLite after the copy starts is
+  lost. Bring the single-stack deployment down before running, then cut over.
+- **Same ``ENCRYPTION_KEY``** on the target deployment, or stored credentials
+  cannot be decrypted (encrypted columns are copied as-is).
+- Re-running is safe: a non-empty target is refused unless ``--truncate`` wipes
+  it first; ``--truncate`` re-copies cleanly and re-resets sequences.
 """
 
 from __future__ import annotations

--- a/unibridge-service/tests/test_migrate_sqlite_to_postgres.py
+++ b/unibridge-service/tests/test_migrate_sqlite_to_postgres.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.database import ALEMBIC_HEAD_REVISION
+from scripts.migrate_sqlite_to_postgres import _ensure_source_at_head
+
+
+async def _sqlite_source(revision: str | None = ALEMBIC_HEAD_REVISION):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE db_connections (id INTEGER PRIMARY KEY)"))
+        if revision is not None:
+            await conn.execute(
+                text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+            )
+            await conn.execute(
+                text("INSERT INTO alembic_version (version_num) VALUES (:rev)"),
+                {"rev": revision},
+            )
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_ensure_source_at_head_accepts_current_revision():
+    engine = await _sqlite_source()
+    try:
+        await _ensure_source_at_head(engine, {"db_connections", "alembic_version"})
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ensure_source_at_head_rejects_stale_revision():
+    engine = await _sqlite_source("0001_initial")
+    try:
+        with pytest.raises(SystemExit, match="not at Alembic head"):
+            await _ensure_source_at_head(engine, {"db_connections", "alembic_version"})
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ensure_source_at_head_requires_alembic_version_table():
+    engine = await _sqlite_source(None)
+    try:
+        with pytest.raises(SystemExit, match="no alembic_version table"):
+            await _ensure_source_at_head(engine, {"db_connections"})
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경

Blue-green 배포(`scripts/deploy-bluegreen.sh`)는 두 컨테이너가 메타 스토어를 공유하므로 **네트워크 기반 Postgres**를 요구합니다. 하지만 두 가지 공백이 있었습니다:

1. 기존 SQLite 메타 스토어(`data/meta.db`)를 Postgres로 옮기는 절차/코드가 전혀 없었음
2. 앱의 부팅 마이그레이션(`alembic upgrade head`) 자체가 **빈 Postgres에서 실패**함

## 변경 사항

### 1. `unibridge-service/scripts/migrate_sqlite_to_postgres.py` (신규)
일회성 SQLite→Postgres 데이터 이전 스크립트.
- 빈 Postgres 타깃에 ORM 모델로 스키마 생성 + `alembic_version`을 head로 stamp (앱의 in-memory 부트스트랩 경로와 동일)
- FK 의존성 순서로 17개 테이블 배치 스트리밍 복사. **SQLAlchemy 컬럼 타입을 거치므로** `UtcDateTime` → `timestamptz`(UTC-aware) 정확 변환, SQLite `0/1` → Postgres `boolean` 변환
- 복사 후 각 시퀀스를 `max(id)`로 리셋 → 라이브 앱의 다음 INSERT가 복사된 PK와 충돌하지 않음
- 비어있지 않은 타깃은 거부(`--truncate`로 덮어쓰기), `--dry-run` 미리보기 지원
- 암호화 컬럼(`*_encrypted`)은 verbatim 복사 → **타깃은 동일한 `ENCRYPTION_KEY` 필요**

```bash
cd unibridge-service
python -m scripts.migrate_sqlite_to_postgres \
  --source sqlite+aiosqlite:///data/meta.db \
  --target postgresql+asyncpg://unibridge:<pw>@<host>:5432/unibridge
```

### 2. Alembic `version_num` 폭 버그 수정 (`alembic/env.py`)
revision 슬러그가 최대 34자(`0013_resource_owner_alerts_enabled`)인데, Alembic 1.17은 버전 테이블의 `version_num`을 `VARCHAR(32)`로 하드코딩합니다. SQLite는 VARCHAR 길이를 강제하지 않아 드러나지 않았지만, **빈 Postgres에서 `alembic upgrade head`가 0005 단계에서 `StringDataRightTruncationError`로 실패** — blue-green이 강제하는 신규 Postgres 배포가 애초에 head까지 올라갈 수 없었습니다.

`version_table_column_type` 옵션은 이 버전에 없어서 `DefaultImpl.version_table_impl` 훅을 오버라이드해 컬럼을 `VARCHAR(255)`로 넓혔습니다. 기존 버전 테이블은 그대로 재사용(생성 시에만 적용)되어 멱등합니다.

### 3. 문서 (`docs/blue-green-deploy.md`)
Postgres 요구사항 섹션에 마이그레이션 절차를 추가.

## 검증

실제 `postgres:16` 컨테이너로 엔드투엔드 확인:
- ✅ `alembic upgrade head` 전체 체인 0013까지 성공, `version_num` = `varchar(255)`
- ✅ `alembic check` 클린 (모델 ↔ 마이그레이션 일치)
- ✅ 마이그레이션 스크립트: 타임스탬프 tz / boolean / 암호화 / FK 무결성, 시퀀스 리셋(새 INSERT 충돌 없음), 비어있지 않은 타깃 가드 / dry-run 무쓰기 / truncate 재실행 멱등성
- ✅ 백엔드 테스트 1484개 전부 통과
- ✅ ruff 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)