### PR TITLE
feat(monitoring): server (host) monitoring with proactive alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@ LITELLM_PORT=4000
 PROMETHEUS_PORT=9090
 KEYCLOAK_PORT=8443
 
+# Server (host) monitoring — node_exporter scrape job + file_sd targets path.
+# Defaults are fine for the bundled stack; see docs/server-monitoring.md.
+NODE_EXPORTER_JOB=nodes
+PROMETHEUS_FILE_SD_PATH=/etc/prometheus/file_sd/nodes.json
+
 # Blue/green compose deployment
 # The edge proxy owns the public UniBridge HTTPS port. Blue and green UI ports
 # are localhost-only verification ports used before promotion.

--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,7 @@ UNIBRIDGE_NETWORK_NAME=unibridge-net
 UNIBRIDGE_DATA_VOLUME=unibridge_unibridge-data
 ETCD_DATA_VOLUME=unibridge_etcd-data
 PROMETHEUS_DATA_VOLUME=unibridge_prometheus-data
+PROMETHEUS_FILE_SD_VOLUME=unibridge_prometheus-file-sd
 KEYCLOAK_DB_DATA_VOLUME=unibridge_keycloak-db-data
 LITELLM_DB_DATA_VOLUME=unibridge_litellm-db-data
 UNIBRIDGE_DB_DATA_VOLUME=unibridge_unibridge-db-data

--- a/README.md
+++ b/README.md
@@ -291,6 +291,15 @@ Operational defaults in `docker-compose.yml`:
 - `unibridge-service` and `unibridge-ui` run with `init: true` for PID 1 signal handling and child process reaping.
 - Prometheus scrapes APISIX, LiteLLM, unibridge-service `/metrics`, and Blackbox TCP probes for the Postgres-backed services. Alert rules live under `prometheus/rules/`.
 
+### Server (host) monitoring
+
+Register Linux servers running `node_exporter` to monitor reachability, disk
+(with a `predict_linear` disk-fill forecast), CPU, and memory, with proactive
+alerts routed through the existing 담당자/관리자 alert pipeline. Install the agent
+with [`scripts/install_node_exporter.sh`](./scripts/install_node_exporter.sh),
+add the host in the UI under **Servers**, and tune thresholds globally (Alert
+settings) or per host. Full guide: [`docs/server-monitoring.md`](./docs/server-monitoring.md).
+
 ## Backups
 
 Stateful components (etcd, Keycloak DB, LiteLLM DB, unibridge-service meta DB) are backed up by scripts in [`backup/`](./backup/README.md). Snapshots land in `./snapshots/` (gitignored) with 14-day retention, and manifest SHA256s are verified before any destructive restore.

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -50,6 +50,8 @@ services:
       - APISIX_UNIBRIDGE_SERVICE_NODE=${APISIX_UNIBRIDGE_SERVICE_NODE:-unibridge-service-${APP_COLOR}:8000}
       - APISIX_LLM_CONVERTER_NODE=${APISIX_LLM_CONVERTER_NODE:-llm-converter-${APP_COLOR}:4001}
       - PROMETHEUS_URL=${PROMETHEUS_URL:-http://prometheus:9090}
+      - NODE_EXPORTER_JOB=${NODE_EXPORTER_JOB:-nodes}
+      - PROMETHEUS_FILE_SD_PATH=${PROMETHEUS_FILE_SD_PATH:-/etc/prometheus/file_sd/nodes.json}
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY is required}
       - KEYCLOAK_ISSUER_URL=${KEYCLOAK_ISSUER_URL:-}
       - KEYCLOAK_JWKS_URL=${KEYCLOAK_JWKS_URL:-}
@@ -80,6 +82,8 @@ services:
       - SSL_CERT_FILE=${CONTAINER_CA_BUNDLE_PATH:-/etc/ssl/certs/ca-certificates.crt}
     volumes:
       - unibridge-data:/app/data
+      # Writes Prometheus file_sd targets from the MonitoredHost registry.
+      - prometheus-file-sd:/etc/prometheus/file_sd
       - type: bind
         source: ${NAS_HOST_PATH:-/mnt/nas}
         target: ${NAS_CONTAINER_PATH:-/mnt/nas}
@@ -208,3 +212,5 @@ networks:
 volumes:
   unibridge-data:
     name: ${UNIBRIDGE_DATA_VOLUME:-unibridge_unibridge-data}
+  prometheus-file-sd:
+    name: ${PROMETHEUS_FILE_SD_VOLUME:-unibridge_prometheus-file-sd}

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -157,6 +157,7 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus-file-sd:/etc/prometheus/file_sd:ro
       - prometheus-data:/prometheus
     depends_on:
       apisix:
@@ -305,6 +306,8 @@ volumes:
     name: ${ETCD_DATA_VOLUME:-unibridge_etcd-data}
   prometheus-data:
     name: ${PROMETHEUS_DATA_VOLUME:-unibridge_prometheus-data}
+  prometheus-file-sd:
+    name: ${PROMETHEUS_FILE_SD_VOLUME:-unibridge_prometheus-file-sd}
   keycloak-db-data:
     name: ${KEYCLOAK_DB_DATA_VOLUME:-unibridge_keycloak-db-data}
   litellm-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,8 @@ services:
       - APISIX_UNIBRIDGE_SERVICE_NODE=${APISIX_UNIBRIDGE_SERVICE_NODE:-unibridge-service:8000}
       - APISIX_LLM_CONVERTER_NODE=${APISIX_LLM_CONVERTER_NODE:-llm-converter:4001}
       - PROMETHEUS_URL=${PROMETHEUS_URL:-http://prometheus:9090}
+      - NODE_EXPORTER_JOB=${NODE_EXPORTER_JOB:-nodes}
+      - PROMETHEUS_FILE_SD_PATH=${PROMETHEUS_FILE_SD_PATH:-/etc/prometheus/file_sd/nodes.json}
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY is required}
       - KEYCLOAK_ISSUER_URL=${KEYCLOAK_ISSUER_URL:-}
       - KEYCLOAK_JWKS_URL=${KEYCLOAK_JWKS_URL:-}
@@ -239,6 +241,8 @@ services:
         condition: service_started
     volumes:
       - unibridge-data:/app/data
+      # Writes Prometheus file_sd targets from the MonitoredHost registry.
+      - prometheus-file-sd:/etc/prometheus/file_sd
       - type: bind
         source: ${NAS_HOST_PATH:-/mnt/nas}
         target: ${NAS_CONTAINER_PATH:-/mnt/nas}
@@ -278,6 +282,7 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus-file-sd:/etc/prometheus/file_sd:ro
       - prometheus-data:/prometheus
     depends_on:
       apisix:
@@ -510,6 +515,9 @@ volumes:
   unibridge-data:
   etcd-data:
   prometheus-data:
+  # Prometheus file_sd targets written by unibridge-service from the
+  # MonitoredHost registry; mounted read-only into Prometheus.
+  prometheus-file-sd:
   keycloak-db-data:
   litellm-db-data:
   unibridge-db-data:

--- a/docs/blue-green-deploy.md
+++ b/docs/blue-green-deploy.md
@@ -155,6 +155,7 @@ when this repo runs as project `unibridge`:
 - `unibridge_keycloak-db-data`
 - `unibridge_litellm-db-data`
 - `unibridge_prometheus-data`
+- `unibridge_prometheus-file-sd`
 
 If the old deployment used a different `COMPOSE_PROJECT_NAME`, set these in
 `.env` before running the split stack:
@@ -166,6 +167,7 @@ ETCD_DATA_VOLUME=<old-project>_etcd-data
 KEYCLOAK_DB_DATA_VOLUME=<old-project>_keycloak-db-data
 LITELLM_DB_DATA_VOLUME=<old-project>_litellm-db-data
 PROMETHEUS_DATA_VOLUME=<old-project>_prometheus-data
+PROMETHEUS_FILE_SD_VOLUME=<old-project>_prometheus-file-sd
 ```
 
 ## First Run

--- a/docs/server-monitoring.md
+++ b/docs/server-monitoring.md
@@ -1,0 +1,94 @@
+# Server (host) monitoring
+
+UniBridge monitors arbitrary Linux servers — the machines your APIs run on, or
+any host you operate — for reachability, disk, CPU, and memory, and raises
+proactive alerts through the existing alert pipeline (per-resource 담당자 +
+global 관리자, webhook/mail channel, alert history, and the Alert Status UI).
+
+## How it works
+
+```
+[server] node_exporter:9100 ─┐
+[server] node_exporter:9100 ─┤→ Prometheus scrape ──→ UniBridge alert_checker
+[server] node_exporter:9100 ─┘   (job "nodes")          (instant_query per signal)
+                                                              │
+                                            AlertStateManager (debounce + severity)
+                                                              │
+                                              dispatch_alert → 담당자 + 관리자
+                                                → webhook/mail + AlertHistory + UI
+```
+
+* Each registered host runs **node_exporter**; UniBridge writes the scrape
+  targets into a Prometheus `file_sd` file (`/etc/prometheus/file_sd/nodes.json`,
+  a shared volume) from the `MonitoredHost` registry — no Prometheus reload
+  needed when you add/remove hosts.
+* The alert checker (the same ~60s loop that checks DB/NAS/route health) queries
+  Prometheus for each host signal, compares against thresholds, and feeds the
+  result through the shared alert-state machine and `dispatch_alert`. No
+  Alertmanager is required — alerts reuse UniBridge recipients, audit, and UI.
+
+## Setup
+
+### 1. Install node_exporter on each server
+
+Run as root on the target host:
+
+```bash
+sudo ./scripts/install_node_exporter.sh            # defaults: v1.8.2, 0.0.0.0:9100
+sudo ./scripts/install_node_exporter.sh 1.8.2 0.0.0.0:9100
+```
+
+Open port 9100 from the central Prometheus host to the server.
+
+### 2. Register the host in UniBridge
+
+UI → **Servers → Add server**, with `address = <host-ip>:9100`. Optionally set
+per-host threshold overrides; leave them blank to inherit the global defaults.
+The status column shows live `up`/`down` from Prometheus.
+
+## Signals & thresholds
+
+| alert_type             | Fires when                                              | Severity |
+|------------------------|---------------------------------------------------------|----------|
+| `server_down`          | node_exporter scrape is down / host unreachable         | critical |
+| `server_disk`          | worst filesystem usage ≥ warn (≥ crit → critical)       | warn/crit|
+| `server_disk_forecast` | disk projected to fill within the forecast horizon      | warning  |
+| `server_cpu`           | CPU utilisation ≥ warn                                   | warning  |
+| `server_mem`           | memory utilisation ≥ warn                               | warning  |
+
+Global defaults live in **Alert settings → Server thresholds**
+(disk warn 80 / crit 90, CPU 90, memory 90, forecast 24h). Per-host overrides
+live on each server. The disk-fill forecast uses Prometheus `predict_linear`
+over a 6h window — a genuine "will fill within N hours" early warning rather
+than a static threshold. Set the forecast horizon to 0 to disable it.
+
+`server_disk` escalates: a warning re-fires as critical when usage crosses the
+crit threshold. Set **Re-notify every N cycles** (`repeat_alert_after_cycles`)
+to re-send a still-firing alert every N check cycles (0 = notify once per
+transition).
+
+## Push mode (firewalled hosts)
+
+When the central Prometheus cannot reach a host's `:9100` (host behind a
+firewall/NAT), run a forwarding agent on the host that pushes metrics out
+instead. Enable the remote-write receiver on Prometheus:
+
+```yaml
+# docker-compose.yml → prometheus.command
+- '--web.enable-remote-write-receiver'
+```
+
+…and on the host run [grafana-agent](https://github.com/grafana/agent) or
+[vmagent](https://docs.victoriametrics.com/vmagent.html) scraping local
+node_exporter and remote-writing to `http(s)://<prometheus-host>:9090/api/v1/write`.
+Add a `host` label in the agent's `external_labels` matching the name you
+registered in UniBridge so the alert checker's queries line up. Pull mode is the
+default and is simpler; use push only for the hosts that need it.
+
+## Not covered yet (future)
+
+* **Windows servers** — add `windows_exporter` and a parallel scrape job; the
+  evaluation queries assume node_exporter metric names.
+* **Container-level metrics** — add cAdvisor for per-container CPU/memory.
+* **Alert grouping/correlation** — multiple signals firing on one host are
+  currently independent alerts.

--- a/docs/server-monitoring.md
+++ b/docs/server-monitoring.md
@@ -8,9 +8,9 @@ global 관리자, webhook/mail channel, alert history, and the Alert Status UI).
 ## How it works
 
 ```
-[server] node_exporter:9100 ─┐
-[server] node_exporter:9100 ─┤→ Prometheus scrape ──→ UniBridge alert_checker
-[server] node_exporter:9100 ─┘   (job "nodes")          (instant_query per signal)
+[server] node_exporter:39100 ─┐
+[server] node_exporter:39100 ─┤→ Prometheus scrape ──→ UniBridge alert_checker
+[server] node_exporter:39100 ─┘   (job "nodes")          (instant_query per signal)
                                                               │
                                             AlertStateManager (debounce + severity)
                                                               │
@@ -34,15 +34,15 @@ global 관리자, webhook/mail channel, alert history, and the Alert Status UI).
 Run as root on the target host:
 
 ```bash
-sudo ./scripts/install_node_exporter.sh            # defaults: v1.8.2, 0.0.0.0:9100
-sudo ./scripts/install_node_exporter.sh 1.8.2 0.0.0.0:9100
+sudo ./scripts/install_node_exporter.sh            # defaults: v1.8.2, 0.0.0.0:39100
+sudo ./scripts/install_node_exporter.sh 1.8.2 0.0.0.0:39100
 ```
 
-Open port 9100 from the central Prometheus host to the server.
+Open port 39100 from the central Prometheus host to the server.
 
 ### 2. Register the host in UniBridge
 
-UI → **Servers → Add server**, with `address = <host-ip>:9100`. Optionally set
+UI → **Servers → Add server**, with `address = <host-ip>:39100`. Optionally set
 per-host threshold overrides; leave them blank to inherit the global defaults.
 The status column shows live `up`/`down` from Prometheus.
 
@@ -69,7 +69,7 @@ transition).
 
 ## Push mode (firewalled hosts)
 
-When the central Prometheus cannot reach a host's `:9100` (host behind a
+When the central Prometheus cannot reach a host's `:39100` (host behind a
 firewall/NAT), run a forwarding agent on the host that pushes metrics out
 instead. Enable the remote-write receiver on Prometheus:
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -25,6 +25,15 @@ scrape_configs:
     metrics_path: '/metrics'
     scrape_interval: 15s
 
+  # Monitored servers (hosts) running node_exporter. Targets are written by
+  # unibridge-service from the MonitoredHost registry into this file_sd file
+  # (shared volume); no Prometheus reload is needed when hosts are added/removed.
+  - job_name: 'nodes'
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/file_sd/nodes.json
+        refresh_interval: 30s
+
   - job_name: 'infra-db-tcp'
     metrics_path: '/probe'
     params:

--- a/scripts/install_node_exporter.sh
+++ b/scripts/install_node_exporter.sh
@@ -7,17 +7,17 @@
 #   ./install_node_exporter.sh [VERSION] [LISTEN_ADDR]
 #
 #   VERSION      node_exporter release, default 1.8.2
-#   LISTEN_ADDR  bind address, default 0.0.0.0:9100
+#   LISTEN_ADDR  bind address, default 0.0.0.0:39100
 #
 # After it runs, register the host in UniBridge (Servers → Add server) with
-# address "<this-host-ip>:9100". The central Prometheus must be able to reach
+# address "<this-host-ip>:39100". The central Prometheus must be able to reach
 # that address (open the port from Prometheus → host). For hosts behind a
 # firewall that Prometheus cannot reach, use push mode instead — see
 # docs/server-monitoring.md.
 set -euo pipefail
 
 VERSION="${1:-1.8.2}"
-LISTEN_ADDR="${2:-0.0.0.0:9100}"
+LISTEN_ADDR="${2:-0.0.0.0:39100}"
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)  GOARCH="amd64" ;;

--- a/scripts/install_node_exporter.sh
+++ b/scripts/install_node_exporter.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# install_node_exporter.sh — install/upgrade Prometheus node_exporter as a
+# systemd service on a Linux host so UniBridge can monitor it.
+#
+# Usage (run as root on the target server):
+#   ./install_node_exporter.sh [VERSION] [LISTEN_ADDR]
+#
+#   VERSION      node_exporter release, default 1.8.2
+#   LISTEN_ADDR  bind address, default 0.0.0.0:9100
+#
+# After it runs, register the host in UniBridge (Servers → Add server) with
+# address "<this-host-ip>:9100". The central Prometheus must be able to reach
+# that address (open the port from Prometheus → host). For hosts behind a
+# firewall that Prometheus cannot reach, use push mode instead — see
+# docs/server-monitoring.md.
+set -euo pipefail
+
+VERSION="${1:-1.8.2}"
+LISTEN_ADDR="${2:-0.0.0.0:9100}"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  GOARCH="amd64" ;;
+  aarch64) GOARCH="arm64" ;;
+  armv7l)  GOARCH="armv7" ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must run as root (sudo)." >&2
+  exit 1
+fi
+
+TARBALL="node_exporter-${VERSION}.linux-${GOARCH}.tar.gz"
+URL="https://github.com/prometheus/node_exporter/releases/download/v${VERSION}/${TARBALL}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "==> Downloading ${URL}"
+curl -fsSL "$URL" -o "${TMP}/${TARBALL}"
+tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
+install -m 0755 "${TMP}/node_exporter-${VERSION}.linux-${GOARCH}/node_exporter" /usr/local/bin/node_exporter
+
+if ! id node_exporter >/dev/null 2>&1; then
+  echo "==> Creating node_exporter system user"
+  useradd --no-create-home --shell /usr/sbin/nologin node_exporter
+fi
+
+echo "==> Writing systemd unit"
+cat > /etc/systemd/system/node_exporter.service <<EOF
+[Unit]
+Description=Prometheus node_exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=${LISTEN_ADDR}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "==> Enabling and starting node_exporter"
+systemctl daemon-reload
+systemctl enable --now node_exporter
+systemctl --no-pager status node_exporter | head -n 5 || true
+
+echo
+echo "node_exporter ${VERSION} listening on ${LISTEN_ADDR}."
+echo "Verify:  curl -s http://localhost:${LISTEN_ADDR##*:}/metrics | head"
+echo "Then register this host in UniBridge → Servers with address <ip>:${LISTEN_ADDR##*:}"

--- a/unibridge-service/alembic/versions/0014_server_monitoring.py
+++ b/unibridge-service/alembic/versions/0014_server_monitoring.py
@@ -1,0 +1,68 @@
+"""Add monitored_hosts table, server alert settings, and alert severity.
+
+Revision ID: 0014_server_monitoring
+Revises: 0013_resource_owner_alerts_enabled
+Create Date: 2026-06-19
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0014_server_monitoring"
+down_revision = "0013_resource_owner_alerts_enabled"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "monitored_hosts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("address", sa.String(length=255), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("labels", sa.Text(), nullable=True),
+        sa.Column("description", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column("disk_warn_pct", sa.Float(), nullable=True),
+        sa.Column("disk_crit_pct", sa.Float(), nullable=True),
+        sa.Column("cpu_warn_pct", sa.Float(), nullable=True),
+        sa.Column("mem_warn_pct", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_monitored_hosts_name", "monitored_hosts", ["name"], unique=True)
+
+    with op.batch_alter_table("alert_settings") as batch_op:
+        batch_op.add_column(sa.Column("server_disk_warn_pct", sa.Float(), nullable=False, server_default="80.0"))
+        batch_op.add_column(sa.Column("server_disk_crit_pct", sa.Float(), nullable=False, server_default="90.0"))
+        batch_op.add_column(sa.Column("server_cpu_warn_pct", sa.Float(), nullable=False, server_default="90.0"))
+        batch_op.add_column(sa.Column("server_mem_warn_pct", sa.Float(), nullable=False, server_default="90.0"))
+        batch_op.add_column(sa.Column("server_disk_forecast_hours", sa.Float(), nullable=False, server_default="24.0"))
+        batch_op.add_column(sa.Column("repeat_alert_after_cycles", sa.Integer(), nullable=False, server_default="0"))
+
+    with op.batch_alter_table("alert_state") as batch_op:
+        batch_op.add_column(sa.Column("severity", sa.String(length=20), nullable=True))
+
+    with op.batch_alter_table("alert_history") as batch_op:
+        batch_op.add_column(sa.Column("severity", sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("alert_history") as batch_op:
+        batch_op.drop_column("severity")
+
+    with op.batch_alter_table("alert_state") as batch_op:
+        batch_op.drop_column("severity")
+
+    with op.batch_alter_table("alert_settings") as batch_op:
+        batch_op.drop_column("repeat_alert_after_cycles")
+        batch_op.drop_column("server_disk_forecast_hours")
+        batch_op.drop_column("server_mem_warn_pct")
+        batch_op.drop_column("server_cpu_warn_pct")
+        batch_op.drop_column("server_disk_crit_pct")
+        batch_op.drop_column("server_disk_warn_pct")
+
+    op.drop_index("ix_monitored_hosts_name", table_name="monitored_hosts")
+    op.drop_table("monitored_hosts")

--- a/unibridge-service/app/auth.py
+++ b/unibridge-service/app/auth.py
@@ -57,6 +57,8 @@ ALL_PERMISSIONS = [
     "nas.connections.read",
     "nas.connections.write",
     "nas.browse",
+    "servers.read",
+    "servers.write",
 ]
 
 # ── Permission cache ────────────────────────────────────────────────────────

--- a/unibridge-service/app/config.py
+++ b/unibridge-service/app/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
     APISIX_UNIBRIDGE_SERVICE_NODE: str = "unibridge-service:8000"
     APISIX_LLM_CONVERTER_NODE: str = "llm-converter:4001"
     PROMETHEUS_URL: str = "http://prometheus:9090"
+    # Server (host) monitoring: Prometheus scrape job for node_exporter agents,
+    # and the file-based service-discovery targets file the service writes from
+    # the MonitoredHost registry (must be on a volume shared with Prometheus).
+    NODE_EXPORTER_JOB: str = "nodes"
+    PROMETHEUS_FILE_SD_PATH: str = "/etc/prometheus/file_sd/nodes.json"
     LITELLM_MASTER_KEY: str = ""
 
     # CORS — comma-separated allowed origins (e.g. "http://localhost:3001,https://app.example.com")

--- a/unibridge-service/app/main.py
+++ b/unibridge-service/app/main.py
@@ -15,8 +15,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app import metrics
 from app.config import settings, validate_settings
 from app.database import get_db, init_db
-from app.models import DBConnection, NASConnection
-from app.routers import admin, alerts, api_keys, gateway, nas, query, query_history, roles, s3, users
+from app.models import DBConnection, MonitoredHost, NASConnection
+from app.routers import admin, alerts, api_keys, gateway, nas, query, query_history, roles, s3, servers, users
 from app.middleware.rate_limiter import RateLimitMiddleware, rate_limiter
 from app.services.connection_manager import connection_manager
 from app.services.s3_manager import s3_manager
@@ -97,6 +97,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         nas_connections = result.scalars().all()
         await nas_manager.initialize(list(nas_connections))
         logger.info("Loaded %d NAS connection(s)", len(nas_connections))
+        break
+
+    logger.info("Reconciling monitored-server scrape targets...")
+    async for db in get_db():
+        from app.services import server_monitor
+        await server_monitor.sync_targets_from_db(db)
         break
 
     logger.info("Loading system settings...")
@@ -455,6 +461,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         known_db_aliases = set(db_aliases_result.scalars().all())
         nas_aliases_result = await db.execute(select(NASConnection.alias))
         known_nas_aliases = set(nas_aliases_result.scalars().all())
+        host_names_result = await db.execute(select(MonitoredHost.name))
+        known_host_names = set(host_names_result.scalars().all())
 
         known_upstream_ids: set[str] | None
         known_route_ids: set[str] | None
@@ -487,6 +495,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             known_nas_aliases=known_nas_aliases,
             known_upstream_ids=known_upstream_ids,
             known_route_ids=known_route_ids,
+            known_host_names=known_host_names,
         )
         break
     set_alert_state(alert_state)
@@ -589,6 +598,7 @@ app.include_router(api_keys.router)
 app.include_router(gateway.router)
 app.include_router(s3.router)
 app.include_router(nas.router)
+app.include_router(servers.router)
 app.include_router(roles.router)
 app.include_router(users.router)
 

--- a/unibridge-service/app/models.py
+++ b/unibridge-service/app/models.py
@@ -282,6 +282,18 @@ class AlertSettings(Base):
         nullable=False,
         server_default="2",
     )
+    # ── Server (host) monitoring global defaults ──────────────────────────────
+    # Percentage thresholds for node_exporter-derived host signals. A per-host
+    # override (MonitoredHost.*) takes precedence when set; otherwise these apply.
+    server_disk_warn_pct = Column(Float, default=80.0, nullable=False, server_default="80.0")
+    server_disk_crit_pct = Column(Float, default=90.0, nullable=False, server_default="90.0")
+    server_cpu_warn_pct = Column(Float, default=90.0, nullable=False, server_default="90.0")
+    server_mem_warn_pct = Column(Float, default=90.0, nullable=False, server_default="90.0")
+    # predict_linear horizon (hours) for "disk will fill within N hours". 0 disables forecasting.
+    server_disk_forecast_hours = Column(Float, default=24.0, nullable=False, server_default="24.0")
+    # Re-notify cadence for a still-firing alert: 0 = notify once per transition;
+    # N = re-dispatch every N check cycles while the alert persists. Applies to all alert types.
+    repeat_alert_after_cycles = Column(Integer, default=0, nullable=False, server_default="0")
     updated_at = Column(UtcDateTime, default=utcnow, onupdate=utcnow, nullable=False)
 
     __table_args__ = (
@@ -301,6 +313,7 @@ class AlertHistory(Base):
     resource_type = Column(String(20), nullable=True)
     alert_type = Column(String(20), nullable=False)  # "triggered" / "resolved"
     target = Column(String(100), nullable=False)
+    severity = Column(String(20), nullable=True)  # "warning" / "critical" (host signals); null for binary types
     message = Column(Text, nullable=False)
     recipients = Column(Text, nullable=True)  # JSON array
     sent_at = Column(UtcDateTime, default=utcnow)
@@ -318,8 +331,40 @@ class AlertState(Base):
     since = Column(UtcDateTime, default=utcnow, nullable=False)
     display_target = Column(String(200), nullable=True)
     fail_count = Column(Integer, default=0, nullable=False, server_default="0")
+    severity = Column(String(20), nullable=True)  # current severity while alerting (host signals)
     updated_at = Column(UtcDateTime, default=utcnow, onupdate=utcnow)
 
     __table_args__ = (
         UniqueConstraint("alert_type", "target", name="uq_alert_state_type_target"),
     )
+
+
+class MonitoredHost(Base):
+    """A server/host monitored via a node_exporter agent scraped by Prometheus.
+
+    ``address`` is the node_exporter endpoint (``host:9100``) and becomes the
+    Prometheus ``instance`` label; ``name`` is the friendly key used as the
+    alert target and the ``host`` relabel applied via file-based service
+    discovery. Per-host threshold columns are nullable overrides — when null,
+    the global :class:`AlertSettings` defaults apply.
+    """
+
+    __tablename__ = "monitored_hosts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(100), unique=True, nullable=False, index=True)
+    address = Column(String(255), nullable=False)  # node_exporter host:port (== prometheus instance)
+    enabled = Column(Boolean, default=True, nullable=False, server_default="true")
+    labels = Column(Text, nullable=True)  # JSON object of extra Prometheus labels
+    description = Column(String(255), default="", nullable=False, server_default="")
+    # Per-host threshold overrides (null → fall back to AlertSettings global defaults)
+    disk_warn_pct = Column(Float, nullable=True)
+    disk_crit_pct = Column(Float, nullable=True)
+    cpu_warn_pct = Column(Float, nullable=True)
+    mem_warn_pct = Column(Float, nullable=True)
+    created_at = Column(UtcDateTime, default=utcnow, nullable=False)
+    updated_at = Column(UtcDateTime, default=utcnow, onupdate=utcnow, nullable=False)
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("enabled", True)
+        super().__init__(**kwargs)

--- a/unibridge-service/app/routers/alerts.py
+++ b/unibridge-service/app/routers/alerts.py
@@ -144,6 +144,14 @@ def _settings_audit_snapshot(settings: AlertSettings) -> dict[str, Any]:
     }
 
 
+def _validate_settings_disk_thresholds(settings: AlertSettings) -> None:
+    if settings.server_disk_warn_pct > settings.server_disk_crit_pct:
+        raise HTTPException(
+            status_code=422,
+            detail="server_disk_warn_pct must be less than or equal to server_disk_crit_pct",
+        )
+
+
 def _channel_audit_snapshot(ch: AlertChannel) -> dict[str, Any]:
     """Audit snapshot of an alert channel. Webhook URLs can embed tokens in
     their path (e.g. Slack/Teams hooks) and headers carry auth secrets, so the
@@ -329,6 +337,7 @@ async def update_alert_settings(
         settings.server_disk_forecast_hours = body.server_disk_forecast_hours
     if body.repeat_alert_after_cycles is not None:
         settings.repeat_alert_after_cycles = body.repeat_alert_after_cycles
+    _validate_settings_disk_thresholds(settings)
     await db.commit()
     await db.refresh(settings)
 

--- a/unibridge-service/app/routers/alerts.py
+++ b/unibridge-service/app/routers/alerts.py
@@ -19,6 +19,7 @@ from app.models import (
     AlertHistory,
     AlertSettings,
     DBConnection,
+    MonitoredHost,
     NASConnection,
     ResourceOwner,
     S3Connection,
@@ -52,7 +53,7 @@ def _mask_webhook_url(url: str) -> str:
     return f"{parsed.scheme}://{host}/***"
 
 
-RESOURCE_TYPES = {"db", "s3", "nas", "route"}
+RESOURCE_TYPES = {"db", "s3", "nas", "route", "server"}
 APISIX_RESOURCE_TYPES = {
     "route": "routes",
 }
@@ -117,6 +118,12 @@ def _build_settings_response(settings: AlertSettings) -> AlertSettingsResponse:
         route_error_threshold_pct=settings.route_error_threshold_pct,
         check_interval_seconds=settings.check_interval_seconds,
         trigger_after_failures=settings.trigger_after_failures,
+        server_disk_warn_pct=settings.server_disk_warn_pct,
+        server_disk_crit_pct=settings.server_disk_crit_pct,
+        server_cpu_warn_pct=settings.server_cpu_warn_pct,
+        server_mem_warn_pct=settings.server_mem_warn_pct,
+        server_disk_forecast_hours=settings.server_disk_forecast_hours,
+        repeat_alert_after_cycles=settings.repeat_alert_after_cycles,
         updated_at=settings.updated_at,
     )
 
@@ -128,6 +135,12 @@ def _settings_audit_snapshot(settings: AlertSettings) -> dict[str, Any]:
         "route_error_threshold_pct": settings.route_error_threshold_pct,
         "check_interval_seconds": settings.check_interval_seconds,
         "trigger_after_failures": settings.trigger_after_failures,
+        "server_disk_warn_pct": settings.server_disk_warn_pct,
+        "server_disk_crit_pct": settings.server_disk_crit_pct,
+        "server_cpu_warn_pct": settings.server_cpu_warn_pct,
+        "server_mem_warn_pct": settings.server_mem_warn_pct,
+        "server_disk_forecast_hours": settings.server_disk_forecast_hours,
+        "repeat_alert_after_cycles": settings.repeat_alert_after_cycles,
     }
 
 
@@ -186,6 +199,9 @@ async def _resource_display_name(
     if resource_type == "nas":
         result = await db.execute(select(NASConnection.alias).where(NASConnection.alias == resource_id))
         return result.scalar_one_or_none()
+    if resource_type == "server":
+        result = await db.execute(select(MonitoredHost.name).where(MonitoredHost.name == resource_id))
+        return result.scalar_one_or_none()
 
     items = await _load_apisix_resources(resource_type)
     for item in items:
@@ -233,6 +249,17 @@ async def _list_resources_for_owners(db: AsyncSession) -> list[ResourceOwnerResp
             resource_type="nas",
             resource_id=alias,
             display_name=alias,
+            emails=_parse_emails(owner.emails) if owner is not None else [],
+            alerts_enabled=owner.alerts_enabled if owner is not None else True,
+        ))
+
+    server_result = await db.execute(select(MonitoredHost.name).order_by(MonitoredHost.name))
+    for name in server_result.scalars().all():
+        owner = owners.get(("server", name))
+        rows.append(ResourceOwnerResponse(
+            resource_type="server",
+            resource_id=name,
+            display_name=name,
             emails=_parse_emails(owner.emails) if owner is not None else [],
             alerts_enabled=owner.alerts_enabled if owner is not None else True,
         ))
@@ -290,6 +317,18 @@ async def update_alert_settings(
         settings.check_interval_seconds = body.check_interval_seconds
     if body.trigger_after_failures is not None:
         settings.trigger_after_failures = body.trigger_after_failures
+    if body.server_disk_warn_pct is not None:
+        settings.server_disk_warn_pct = body.server_disk_warn_pct
+    if body.server_disk_crit_pct is not None:
+        settings.server_disk_crit_pct = body.server_disk_crit_pct
+    if body.server_cpu_warn_pct is not None:
+        settings.server_cpu_warn_pct = body.server_cpu_warn_pct
+    if body.server_mem_warn_pct is not None:
+        settings.server_mem_warn_pct = body.server_mem_warn_pct
+    if body.server_disk_forecast_hours is not None:
+        settings.server_disk_forecast_hours = body.server_disk_forecast_hours
+    if body.repeat_alert_after_cycles is not None:
+        settings.repeat_alert_after_cycles = body.repeat_alert_after_cycles
     await db.commit()
     await db.refresh(settings)
 
@@ -736,7 +775,7 @@ async def list_history(
     return [
         AlertHistoryResponse(
             id=h.id, channel_id=h.channel_id,
-            alert_type=h.alert_type, target=h.target, message=h.message,
+            alert_type=h.alert_type, target=h.target, severity=h.severity, message=h.message,
             recipients=json.loads(h.recipients) if h.recipients else None,
             sent_at=h.sent_at, success=h.success, error_detail=h.error_detail,
         )
@@ -754,6 +793,11 @@ def set_alert_state(state) -> None:
     _alert_state = state
 
 
+def get_alert_state():
+    """Return the live AlertStateManager (or None before startup wiring)."""
+    return _alert_state
+
+
 @router.get("/status", response_model=list[AlertStatusResponse])
 async def alert_status(
     _user: CurrentUser = Depends(require_permission("alerts.read")),
@@ -762,6 +806,9 @@ async def alert_status(
         return []
     alerts = _alert_state.get_all_statuses()
     return [
-        AlertStatusResponse(target=a["target"], type=a["type"], status=a["status"], since=a["since"])
+        AlertStatusResponse(
+            target=a["target"], type=a["type"], status=a["status"],
+            since=a["since"], severity=a.get("severity"),
+        )
         for a in alerts
     ]

--- a/unibridge-service/app/routers/servers.py
+++ b/unibridge-service/app/routers/servers.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import CurrentUser, require_permission
 from app.database import get_db
-from app.models import MonitoredHost
+from app.models import AlertSettings, MonitoredHost
 from app.schemas import (
     MonitoredHostCreate,
     MonitoredHostResponse,
@@ -35,6 +35,34 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/admin/servers", tags=["Servers"])
 
 _METRICS = {"cpu", "mem", "disk"}
+
+
+def _reject_invalid_disk_thresholds(warn: float, crit: float) -> None:
+    if warn > crit:
+        raise HTTPException(
+            status_code=422,
+            detail="disk_warn_pct must be less than or equal to disk_crit_pct",
+        )
+
+
+async def _global_disk_thresholds(db: AsyncSession) -> tuple[float, float]:
+    result = await db.execute(select(AlertSettings).where(AlertSettings.id == 1))
+    settings = result.scalar_one_or_none()
+    if settings is None:
+        return 80.0, 90.0
+    return float(settings.server_disk_warn_pct), float(settings.server_disk_crit_pct)
+
+
+async def _validate_effective_disk_thresholds(
+    db: AsyncSession,
+    *,
+    warn: float | None,
+    crit: float | None,
+) -> None:
+    global_warn, global_crit = await _global_disk_thresholds(db)
+    effective_warn = float(warn) if warn is not None else global_warn
+    effective_crit = float(crit) if crit is not None else global_crit
+    _reject_invalid_disk_thresholds(effective_warn, effective_crit)
 
 
 def _parse_labels(labels_json: str | None) -> dict[str, str] | None:
@@ -120,6 +148,11 @@ async def create_server(
     _user: CurrentUser = Depends(require_permission("servers.write")),
     db: AsyncSession = Depends(get_db),
 ) -> MonitoredHostResponse:
+    await _validate_effective_disk_thresholds(
+        db,
+        warn=body.disk_warn_pct,
+        crit=body.disk_crit_pct,
+    )
     host = MonitoredHost(
         name=body.name,
         address=body.address,
@@ -158,6 +191,13 @@ async def update_server(
     if host is None:
         raise HTTPException(status_code=404, detail="Server not found")
     before = _audit_snapshot(host)
+    next_disk_warn = body.disk_warn_pct if "disk_warn_pct" in body.model_fields_set else host.disk_warn_pct
+    next_disk_crit = body.disk_crit_pct if "disk_crit_pct" in body.model_fields_set else host.disk_crit_pct
+    await _validate_effective_disk_thresholds(
+        db,
+        warn=next_disk_warn,
+        crit=next_disk_crit,
+    )
     if body.address is not None:
         host.address = body.address
     if body.enabled is not None:
@@ -175,6 +215,7 @@ async def update_server(
     # doesn't linger as a stale "down" while unscraped.
     if not host.enabled:
         await _clear_host_alert_state(db, host.name)
+        await db.commit()
     await server_monitor.sync_targets_from_db(db)
     await log_admin_action(
         db, actor=_user.username, action="update",

--- a/unibridge-service/app/routers/servers.py
+++ b/unibridge-service/app/routers/servers.py
@@ -1,0 +1,259 @@
+"""Monitored-server (host) registry + live status and metrics.
+
+CRUD over :class:`~app.models.MonitoredHost`. Each mutation rewrites the
+Prometheus file_sd targets so the scrape set tracks the registry, and clears
+any alert state for a removed/renamed host. Live status and per-host metric
+time series are read straight from Prometheus.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import CurrentUser, require_permission
+from app.database import get_db
+from app.models import MonitoredHost
+from app.schemas import (
+    MonitoredHostCreate,
+    MonitoredHostResponse,
+    MonitoredHostUpdate,
+    ServerMetricPoint,
+    ServerMetricSeries,
+)
+from app.services import prometheus_client, server_monitor
+from app.services.alert_state import delete_alert_state
+from app.services.audit import log_admin_action
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/servers", tags=["Servers"])
+
+_METRICS = {"cpu", "mem", "disk"}
+
+
+def _parse_labels(labels_json: str | None) -> dict[str, str] | None:
+    if not labels_json:
+        return None
+    try:
+        parsed = json.loads(labels_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return {str(k): str(v) for k, v in parsed.items()}
+
+
+def _host_response(host: MonitoredHost, status: str | None = None) -> MonitoredHostResponse:
+    return MonitoredHostResponse(
+        id=host.id,
+        name=host.name,
+        address=host.address,
+        enabled=host.enabled,
+        description=host.description or "",
+        labels=_parse_labels(host.labels),
+        disk_warn_pct=host.disk_warn_pct,
+        disk_crit_pct=host.disk_crit_pct,
+        cpu_warn_pct=host.cpu_warn_pct,
+        mem_warn_pct=host.mem_warn_pct,
+        status=status,
+        created_at=host.created_at,
+        updated_at=host.updated_at,
+    )
+
+
+def _audit_snapshot(host: MonitoredHost) -> dict[str, Any]:
+    return {
+        "name": host.name,
+        "address": host.address,
+        "enabled": host.enabled,
+        "description": host.description or "",
+        "labels": _parse_labels(host.labels),
+        "disk_warn_pct": host.disk_warn_pct,
+        "disk_crit_pct": host.disk_crit_pct,
+        "cpu_warn_pct": host.cpu_warn_pct,
+        "mem_warn_pct": host.mem_warn_pct,
+    }
+
+
+async def _clear_host_alert_state(db: AsyncSession, host_name: str) -> None:
+    """Drop in-memory + persisted alert state for every signal of a host."""
+    from app.routers.alerts import get_alert_state
+
+    state = get_alert_state()
+    for alert_type in server_monitor.SERVER_ALERT_TYPES:
+        if state is not None:
+            state.discard(alert_type, host_name)
+        await delete_alert_state(db, alert_type, host_name)
+
+
+@router.get("", response_model=list[MonitoredHostResponse])
+async def list_servers(
+    _user: CurrentUser = Depends(require_permission("servers.read")),
+    db: AsyncSession = Depends(get_db),
+) -> list[MonitoredHostResponse]:
+    result = await db.execute(select(MonitoredHost).order_by(MonitoredHost.name))
+    hosts = result.scalars().all()
+    up_map = await server_monitor.host_up_map()  # None if Prometheus unreachable
+    rows: list[MonitoredHostResponse] = []
+    for host in hosts:
+        if not host.enabled:
+            status = "disabled"
+        elif up_map is None:
+            status = "unknown"
+        elif host.name in up_map:
+            status = "up" if up_map[host.name] else "down"
+        else:
+            status = "unknown"
+        rows.append(_host_response(host, status))
+    return rows
+
+
+@router.post("", response_model=MonitoredHostResponse, status_code=201)
+async def create_server(
+    body: MonitoredHostCreate,
+    _user: CurrentUser = Depends(require_permission("servers.write")),
+    db: AsyncSession = Depends(get_db),
+) -> MonitoredHostResponse:
+    host = MonitoredHost(
+        name=body.name,
+        address=body.address,
+        enabled=body.enabled,
+        description=body.description,
+        labels=json.dumps(body.labels, ensure_ascii=False) if body.labels else None,
+        disk_warn_pct=body.disk_warn_pct,
+        disk_crit_pct=body.disk_crit_pct,
+        cpu_warn_pct=body.cpu_warn_pct,
+        mem_warn_pct=body.mem_warn_pct,
+    )
+    db.add(host)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=f"Server '{body.name}' already exists")
+    await db.refresh(host)
+    await server_monitor.sync_targets_from_db(db)
+    await log_admin_action(
+        db, actor=_user.username, action="create",
+        resource_type="monitored_host", resource_id=host.name, summary=host.address,
+        before=None, after=_audit_snapshot(host),
+    )
+    return _host_response(host)
+
+
+@router.put("/{host_id}", response_model=MonitoredHostResponse)
+async def update_server(
+    host_id: int,
+    body: MonitoredHostUpdate,
+    _user: CurrentUser = Depends(require_permission("servers.write")),
+    db: AsyncSession = Depends(get_db),
+) -> MonitoredHostResponse:
+    host = await db.get(MonitoredHost, host_id)
+    if host is None:
+        raise HTTPException(status_code=404, detail="Server not found")
+    before = _audit_snapshot(host)
+    if body.address is not None:
+        host.address = body.address
+    if body.enabled is not None:
+        host.enabled = body.enabled
+    if body.description is not None:
+        host.description = body.description
+    if "labels" in body.model_fields_set:
+        host.labels = json.dumps(body.labels, ensure_ascii=False) if body.labels else None
+    for field in ("disk_warn_pct", "disk_crit_pct", "cpu_warn_pct", "mem_warn_pct"):
+        if field in body.model_fields_set:
+            setattr(host, field, getattr(body, field))
+    await db.commit()
+    await db.refresh(host)
+    # A disabled host is dropped from the scrape set; clear its alert state so it
+    # doesn't linger as a stale "down" while unscraped.
+    if not host.enabled:
+        await _clear_host_alert_state(db, host.name)
+    await server_monitor.sync_targets_from_db(db)
+    await log_admin_action(
+        db, actor=_user.username, action="update",
+        resource_type="monitored_host", resource_id=host.name, summary=host.address,
+        before=before, after=_audit_snapshot(host),
+    )
+    return _host_response(host)
+
+
+@router.delete("/{host_id}", status_code=204, response_model=None)
+async def delete_server(
+    host_id: int,
+    _user: CurrentUser = Depends(require_permission("servers.write")),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    host = await db.get(MonitoredHost, host_id)
+    if host is None:
+        raise HTTPException(status_code=404, detail="Server not found")
+    before = _audit_snapshot(host)
+    host_name = host.name
+    await _clear_host_alert_state(db, host_name)
+    await db.delete(host)
+    await db.commit()
+    await server_monitor.sync_targets_from_db(db)
+    await log_admin_action(
+        db, actor=_user.username, action="delete",
+        resource_type="monitored_host", resource_id=host_name, summary=before["address"],
+        before=before, after=None,
+    )
+
+
+@router.post("/{host_id}/test")
+async def test_server(
+    host_id: int,
+    _user: CurrentUser = Depends(require_permission("servers.read")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    host = await db.get(MonitoredHost, host_id)
+    if host is None:
+        raise HTTPException(status_code=404, detail="Server not found")
+    up_map = await server_monitor.host_up_map()
+    if up_map is None:
+        return {"status": "unknown", "detail": "Prometheus unreachable"}
+    if host.name not in up_map:
+        return {"status": "unknown", "detail": "No scrape data yet for this host"}
+    return {"status": "up" if up_map[host.name] else "down", "detail": None}
+
+
+@router.get("/{host_id}/metrics", response_model=list[ServerMetricSeries])
+async def server_metrics(
+    host_id: int,
+    duration: str = Query("1h"),
+    step: str = Query("60s"),
+    _user: CurrentUser = Depends(require_permission("servers.read")),
+    db: AsyncSession = Depends(get_db),
+) -> list[ServerMetricSeries]:
+    host = await db.get(MonitoredHost, host_id)
+    if host is None:
+        raise HTTPException(status_code=404, detail="Server not found")
+
+    series: list[ServerMetricSeries] = []
+    for metric in ("cpu", "mem", "disk"):
+        query = server_monitor.metric_query(metric, host.name)
+        if query is None:
+            continue
+        try:
+            results = await prometheus_client.range_query(query, duration=duration, step=step)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Server metric query failed (%s/%s): %s", host.name, metric, exc)
+            results = []
+        points: list[ServerMetricPoint] = []
+        if results:
+            for ts, raw in results[0].get("values", []):
+                try:
+                    value = float(raw)
+                except (TypeError, ValueError):
+                    value = None
+                if value is not None and value != value:  # NaN
+                    value = None
+                points.append(ServerMetricPoint(t=float(ts), v=value))
+        series.append(ServerMetricSeries(metric=metric, points=points))
+    return series

--- a/unibridge-service/app/schemas.py
+++ b/unibridge-service/app/schemas.py
@@ -611,6 +611,12 @@ class AlertSettingsUpdate(BaseModel):
         ):
             if field_name in self.model_fields_set and getattr(self, field_name) is None:
                 raise ValueError(f"{field_name} cannot be null")
+        _validate_disk_threshold_order(
+            self.server_disk_warn_pct,
+            self.server_disk_crit_pct,
+            warn_name="server_disk_warn_pct",
+            crit_name="server_disk_crit_pct",
+        )
         return self
 
 
@@ -694,6 +700,17 @@ class AlertStatusResponse(BaseModel):
 _HOST_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
+def _validate_disk_threshold_order(
+    warn: float | None,
+    crit: float | None,
+    *,
+    warn_name: str = "disk_warn_pct",
+    crit_name: str = "disk_crit_pct",
+) -> None:
+    if warn is not None and crit is not None and warn > crit:
+        raise ValueError(f"{warn_name} must be less than or equal to {crit_name}")
+
+
 def _validate_host_name(name: str) -> str:
     name = name.strip()
     if not _HOST_NAME_RE.match(name):
@@ -736,6 +753,11 @@ class MonitoredHostCreate(BaseModel):
     def check_address(cls, v: str) -> str:
         return _validate_host_address(v)
 
+    @model_validator(mode="after")
+    def validate_disk_threshold_order(self) -> "MonitoredHostCreate":
+        _validate_disk_threshold_order(self.disk_warn_pct, self.disk_crit_pct)
+        return self
+
 
 class MonitoredHostUpdate(BaseModel):
     address: str | None = Field(None, min_length=1, max_length=255)
@@ -751,6 +773,11 @@ class MonitoredHostUpdate(BaseModel):
     @classmethod
     def check_address(cls, v: str | None) -> str | None:
         return _validate_host_address(v) if v is not None else v
+
+    @model_validator(mode="after")
+    def validate_disk_threshold_order(self) -> "MonitoredHostUpdate":
+        _validate_disk_threshold_order(self.disk_warn_pct, self.disk_crit_pct)
+        return self
 
 
 class MonitoredHostResponse(BaseModel):

--- a/unibridge-service/app/schemas.py
+++ b/unibridge-service/app/schemas.py
@@ -568,6 +568,12 @@ class AlertSettingsResponse(BaseModel):
     route_error_threshold_pct: float
     check_interval_seconds: int
     trigger_after_failures: int
+    server_disk_warn_pct: float
+    server_disk_crit_pct: float
+    server_cpu_warn_pct: float
+    server_mem_warn_pct: float
+    server_disk_forecast_hours: float
+    repeat_alert_after_cycles: int
     updated_at: datetime | None = None
 
 
@@ -577,6 +583,12 @@ class AlertSettingsUpdate(BaseModel):
     route_error_threshold_pct: float | None = Field(None, ge=0, le=100)
     check_interval_seconds: int | None = Field(None, ge=30, le=3600)
     trigger_after_failures: int | None = Field(None, ge=1, le=10)
+    server_disk_warn_pct: float | None = Field(None, ge=0, le=100)
+    server_disk_crit_pct: float | None = Field(None, ge=0, le=100)
+    server_cpu_warn_pct: float | None = Field(None, ge=0, le=100)
+    server_mem_warn_pct: float | None = Field(None, ge=0, le=100)
+    server_disk_forecast_hours: float | None = Field(None, ge=0, le=720)
+    repeat_alert_after_cycles: int | None = Field(None, ge=0, le=1000)
 
     @field_validator("admin_emails")
     @classmethod
@@ -590,6 +602,12 @@ class AlertSettingsUpdate(BaseModel):
             "route_error_threshold_pct",
             "check_interval_seconds",
             "trigger_after_failures",
+            "server_disk_warn_pct",
+            "server_disk_crit_pct",
+            "server_cpu_warn_pct",
+            "server_mem_warn_pct",
+            "server_disk_forecast_hours",
+            "repeat_alert_after_cycles",
         ):
             if field_name in self.model_fields_set and getattr(self, field_name) is None:
                 raise ValueError(f"{field_name} cannot be null")
@@ -653,6 +671,7 @@ class AlertHistoryResponse(BaseModel):
     channel_id: int | None = None
     alert_type: str
     target: str
+    severity: str | None = None
     message: str
     recipients: list[str] | None = None
     sent_at: datetime | None = None
@@ -667,6 +686,97 @@ class AlertStatusResponse(BaseModel):
     type: str
     status: str  # "ok" | "alert"
     since: str | None = None
+    severity: str | None = None
+
+
+# ── Monitored servers (hosts) ─────────────────────────────────────────────────
+
+_HOST_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _validate_host_name(name: str) -> str:
+    name = name.strip()
+    if not _HOST_NAME_RE.match(name):
+        raise ValueError(
+            "name must start alphanumeric and contain only letters, digits, '.', '_', '-'"
+        )
+    return name
+
+
+def _validate_host_address(address: str) -> str:
+    address = address.strip()
+    if ":" not in address:
+        raise ValueError("address must be in host:port form (e.g. 10.0.0.5:9100)")
+    host, _, port = address.rpartition(":")
+    if not host:
+        raise ValueError("address must include a host")
+    if not port.isdigit() or not (1 <= int(port) <= 65535):
+        raise ValueError("address port must be a number between 1 and 65535")
+    return address
+
+
+class MonitoredHostCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    address: str = Field(..., min_length=1, max_length=255)
+    enabled: bool = True
+    description: str = Field("", max_length=255)
+    labels: dict[str, str] | None = None
+    disk_warn_pct: float | None = Field(None, ge=0, le=100)
+    disk_crit_pct: float | None = Field(None, ge=0, le=100)
+    cpu_warn_pct: float | None = Field(None, ge=0, le=100)
+    mem_warn_pct: float | None = Field(None, ge=0, le=100)
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, v: str) -> str:
+        return _validate_host_name(v)
+
+    @field_validator("address")
+    @classmethod
+    def check_address(cls, v: str) -> str:
+        return _validate_host_address(v)
+
+
+class MonitoredHostUpdate(BaseModel):
+    address: str | None = Field(None, min_length=1, max_length=255)
+    enabled: bool | None = None
+    description: str | None = Field(None, max_length=255)
+    labels: dict[str, str] | None = None
+    disk_warn_pct: float | None = Field(None, ge=0, le=100)
+    disk_crit_pct: float | None = Field(None, ge=0, le=100)
+    cpu_warn_pct: float | None = Field(None, ge=0, le=100)
+    mem_warn_pct: float | None = Field(None, ge=0, le=100)
+
+    @field_validator("address")
+    @classmethod
+    def check_address(cls, v: str | None) -> str | None:
+        return _validate_host_address(v) if v is not None else v
+
+
+class MonitoredHostResponse(BaseModel):
+    id: int
+    name: str
+    address: str
+    enabled: bool
+    description: str = ""
+    labels: dict[str, str] | None = None
+    disk_warn_pct: float | None = None
+    disk_crit_pct: float | None = None
+    cpu_warn_pct: float | None = None
+    mem_warn_pct: float | None = None
+    status: str | None = None  # "up" | "down" | "unknown" — live from Prometheus
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class ServerMetricPoint(BaseModel):
+    t: float  # epoch seconds
+    v: float | None = None
+
+
+class ServerMetricSeries(BaseModel):
+    metric: str  # "cpu" | "mem" | "disk"
+    points: list[ServerMetricPoint] = []
 
 
 # ── S3 Connections ──────────────────────────────────────────────────────────

--- a/unibridge-service/app/services/alert_checker.py
+++ b/unibridge-service/app/services/alert_checker.py
@@ -6,9 +6,11 @@ import time
 from sqlalchemy import select
 
 from app.database import async_session
-from app.models import AlertSettings
+from app.models import AlertSettings, MonitoredHost
+from app.services import server_monitor
 from app.services.alert_owner_dispatcher import dispatch_alert
 from app.services.alert_state import AlertStateManager, save_alert_state_to_db
+from app.services.server_monitor import ServerThresholds
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +214,69 @@ async def _check_route_error_rate() -> list[tuple[str, float]] | None:
     return route_rates
 
 
+async def _load_server_monitoring() -> tuple[list[MonitoredHost], ServerThresholds, int]:
+    """Load enabled monitored hosts, global server thresholds, and re-notify cadence."""
+    async with async_session() as db:
+        settings_row = (
+            await db.execute(select(AlertSettings).where(AlertSettings.id == 1))
+        ).scalar_one_or_none()
+        hosts = list((await db.execute(select(MonitoredHost))).scalars().all())
+
+    if settings_row is None:
+        return hosts, ServerThresholds(), 0
+    thresholds = ServerThresholds(
+        disk_warn_pct=settings_row.server_disk_warn_pct,
+        disk_crit_pct=settings_row.server_disk_crit_pct,
+        cpu_warn_pct=settings_row.server_cpu_warn_pct,
+        mem_warn_pct=settings_row.server_mem_warn_pct,
+        forecast_hours=settings_row.server_disk_forecast_hours,
+    )
+    repeat = int(settings_row.repeat_alert_after_cycles or 0)
+    return hosts, thresholds, repeat
+
+
+async def _check_server_health(
+    state: AlertStateManager,
+    *,
+    trigger_after_failures: int,
+) -> None:
+    """Evaluate node_exporter host signals and dispatch transitions.
+
+    Reuses the shared state machine + dispatch pipeline: each signal is one
+    (alert_type, host) binary state, with warn/critical severity escalation and
+    optional re-notification handled by AlertStateManager.
+
+    A failure to load the registry/thresholds is isolated to this step so it
+    can never abort the DB/NAS/upstream/route checks in the same cycle.
+    """
+    try:
+        hosts, thresholds, repeat = await _load_server_monitoring()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Server health check skipped (config load failed): %s", exc)
+        return
+    enabled = [h for h in hosts if getattr(h, "enabled", False)]
+    if not enabled:
+        return
+    signals = await server_monitor.evaluate_hosts(enabled, thresholds)
+    for sig in signals:
+        transition = state.update(
+            sig.alert_type, sig.target,
+            is_healthy=sig.is_healthy,
+            display_target=sig.display,
+            severity=sig.severity,
+            trigger_after_failures=trigger_after_failures,
+            repeat_after_cycles=repeat,
+        )
+        await _persist_state_safely(state, sig.alert_type, sig.target)
+        if transition:
+            await dispatch_alert(
+                resource_type="server", resource_id=sig.target,
+                alert_type=transition, target=sig.target, message=sig.message,
+                display_target=sig.display, rate=sig.value, threshold=sig.threshold,
+                monitor_label=sig.monitor_label, severity=sig.severity,
+            )
+
+
 async def _persist_state_safely(
     state: AlertStateManager,
     alert_type: str,
@@ -318,7 +383,10 @@ async def run_single_check(state: AlertStateManager, *, trigger_after_failures: 
                 display_target=display, monitor_label="업스트림 헬스체크",
             )
 
-    # 4. Route-level error rate (automatic for every route; global threshold)
+    # 4. Server (host) health via node_exporter metrics
+    await _check_server_health(state, trigger_after_failures=trigger_after_failures)
+
+    # 5. Route-level error rate (automatic for every route; global threshold)
     route_results = await _check_route_error_rate()
     if route_results is None:
         return

--- a/unibridge-service/app/services/alert_owner_dispatcher.py
+++ b/unibridge-service/app/services/alert_owner_dispatcher.py
@@ -20,7 +20,7 @@ from app.services.alert_sender import render_recipient_items, render_template, s
 
 logger = logging.getLogger(__name__)
 
-ASSIGNEE_RESOURCE_TYPES = {"db", "s3", "nas", "route"}
+ASSIGNEE_RESOURCE_TYPES = {"db", "s3", "nas", "route", "server"}
 
 
 async def dispatch_alert(
@@ -34,6 +34,7 @@ async def dispatch_alert(
     rate: float | None = None,
     threshold: float | None = None,
     monitor_label: str = "",
+    severity: str | None = None,
 ) -> None:
     """Send an alert to the resource's assignees (담당자) plus the global admins (관리자).
 
@@ -48,6 +49,7 @@ async def dispatch_alert(
         resource_type=resource_type,
         alert_type=alert_type,
         target=target,
+        severity=severity,
         message=message,
         recipients=None,
         success=False,
@@ -106,6 +108,7 @@ async def dispatch_alert(
                 rate=rate,
                 threshold=threshold,
                 monitor_label=monitor_label,
+                severity=severity,
             )
             send_args = {
                 "url": channel_webhook_url,
@@ -240,6 +243,7 @@ def _render_payload(
     rate: float | None,
     threshold: float | None,
     monitor_label: str,
+    severity: str | None = None,
 ) -> str:
     status_label = "장애 발생" if alert_type == "triggered" else "정상 복구"
     return render_template(
@@ -254,4 +258,5 @@ def _render_payload(
         rate=f"{rate:.1f}" if rate is not None else "",
         threshold=f"{threshold:.1f}" if threshold is not None else "",
         rule_name=monitor_label,
+        severity=severity or "",
     )

--- a/unibridge-service/app/services/alert_sender.py
+++ b/unibridge-service/app/services/alert_sender.py
@@ -58,13 +58,14 @@ def render_template(
     rate: str = "",
     threshold: str = "",
     rule_name: str = "",
+    severity: str = "",
 ) -> str:
     """Replace {{placeholders}} in the template string.
 
     Supported placeholders:
       {{alert_type}}, {{target_name}}, {{status}}, {{message}},
       {{timestamp}}, {{recipients}}, {{recipients_json}}, {{rate}},
-      {{threshold}}, {{rule_name}}
+      {{threshold}}, {{rule_name}}, {{severity}}
     Unknown placeholders are left untouched.
     """
     replacements = {
@@ -78,6 +79,7 @@ def render_template(
         "{{rate}}": rate,
         "{{threshold}}": threshold,
         "{{rule_name}}": rule_name,
+        "{{severity}}": severity,
     }
     result = template
     for placeholder, value in replacements.items():

--- a/unibridge-service/app/services/alert_state.py
+++ b/unibridge-service/app/services/alert_state.py
@@ -13,11 +13,20 @@ from app.models import AlertState
 logger = logging.getLogger(__name__)
 
 
+_SEVERITY_RANK = {"warning": 1, "critical": 2}
+
+
+def _severity_rank(severity: str | None) -> int:
+    return _SEVERITY_RANK.get(severity or "", 0)
+
+
 class AlertStateManager:
     """In-memory alert state tracker.
 
     Each entry: status ∈ {"ok", "alert"}, fail_count is the consecutive
     failure tally, since is the timestamp of the most recent status flip.
+    ``severity`` (optional) carries the current host-signal severity while
+    alerting, and ``cycles_in_alert`` drives re-notification cadence.
     """
 
     def __init__(self) -> None:
@@ -38,6 +47,7 @@ class AlertStateManager:
             "since": entry["since"],
             "display_target": entry.get("display_target", target),
             "fail_count": entry.get("fail_count", 0),
+            "severity": entry.get("severity"),
         }
 
     def set_entry(
@@ -49,12 +59,15 @@ class AlertStateManager:
         since: str,
         display_target: str | None = None,
         fail_count: int = 0,
+        severity: str | None = None,
     ) -> None:
         self._states[(alert_type, target)] = {
             "status": status,
             "since": since,
             "display_target": display_target or target,
             "fail_count": fail_count,
+            "severity": severity,
+            "cycles_in_alert": 0,
         }
 
     def update(
@@ -65,11 +78,19 @@ class AlertStateManager:
         is_healthy: bool,
         trigger_after_failures: int,
         display_target: str | None = None,
+        severity: str | None = None,
+        repeat_after_cycles: int = 0,
     ) -> str | None:
         """Update state and return transition type if changed.
 
         Returns "triggered" / "resolved" / None. fail_count drives status:
         flip to "alert" only when fail_count reaches trigger_after_failures.
+
+        ``severity`` (host signals) enables escalation: while already alerting,
+        a rise in severity (e.g. warning → critical) re-fires "triggered".
+        ``repeat_after_cycles`` > 0 re-fires "triggered" every N unhealthy
+        cycles while the alert persists. Callers that pass neither keep the
+        original binary behaviour exactly.
         """
         key = (alert_type, target)
         now = datetime.now(timezone.utc).isoformat()
@@ -77,30 +98,25 @@ class AlertStateManager:
 
         if entry is None:
             if is_healthy:
-                self._states[key] = {
-                    "status": "ok",
-                    "since": now,
-                    "display_target": display_target or target,
-                    "fail_count": 0,
-                }
+                self.set_entry(
+                    alert_type, target,
+                    status="ok", since=now, display_target=display_target, fail_count=0,
+                )
                 logger.info("Alert state %s/%s initialized as ok", alert_type, target)
                 return None
             fail_count = 1
             if fail_count >= trigger_after_failures:
-                self._states[key] = {
-                    "status": "alert",
-                    "since": now,
-                    "display_target": display_target or target,
-                    "fail_count": fail_count,
-                }
+                self.set_entry(
+                    alert_type, target,
+                    status="alert", since=now, display_target=display_target,
+                    fail_count=fail_count, severity=severity,
+                )
                 logger.info("Alert state %s/%s initialized as alert", alert_type, target)
                 return "triggered"
-            self._states[key] = {
-                "status": "ok",
-                "since": now,
-                "display_target": display_target or target,
-                "fail_count": fail_count,
-            }
+            self.set_entry(
+                alert_type, target,
+                status="ok", since=now, display_target=display_target, fail_count=fail_count,
+            )
             logger.info(
                 "Alert state %s/%s initialized as ok (fail_count=%d)",
                 alert_type, target, fail_count,
@@ -114,9 +130,11 @@ class AlertStateManager:
         if is_healthy:
             was_alert = entry["status"] == "alert"
             entry["fail_count"] = 0
+            entry["cycles_in_alert"] = 0
             if was_alert:
                 entry["status"] = "ok"
                 entry["since"] = now
+                entry["severity"] = None
                 logger.info("Alert state %s/%s: alert → ok", alert_type, target)
                 return "resolved"
             return None
@@ -125,10 +143,28 @@ class AlertStateManager:
         entry["fail_count"] = entry.get("fail_count", 0) + 1
         if entry["status"] == "alert":
             entry["fail_count"] = min(entry["fail_count"], trigger_after_failures)
+            # Severity escalation: a rise re-fires immediately; a fall is recorded silently.
+            if severity is not None and _severity_rank(severity) != _severity_rank(entry.get("severity")):
+                escalated = _severity_rank(severity) > _severity_rank(entry.get("severity"))
+                entry["severity"] = severity
+                if escalated:
+                    entry["since"] = now
+                    entry["cycles_in_alert"] = 0
+                    logger.info("Alert state %s/%s escalated to %s", alert_type, target, severity)
+                    return "triggered"
+            # Re-notification cadence while still firing.
+            if repeat_after_cycles and repeat_after_cycles > 0:
+                entry["cycles_in_alert"] = entry.get("cycles_in_alert", 0) + 1
+                if entry["cycles_in_alert"] >= repeat_after_cycles:
+                    entry["cycles_in_alert"] = 0
+                    logger.info("Alert state %s/%s re-notifying (every %d cycles)", alert_type, target, repeat_after_cycles)
+                    return "triggered"
             return None
         if entry["fail_count"] >= trigger_after_failures:
             entry["status"] = "alert"
             entry["since"] = now
+            entry["severity"] = severity
+            entry["cycles_in_alert"] = 0
             logger.info(
                 "Alert state %s/%s: ok → alert (fail_count=%d, threshold=%d)",
                 alert_type, target, entry["fail_count"], trigger_after_failures,
@@ -155,6 +191,7 @@ class AlertStateManager:
                 "target": v.get("display_target", k[1]),
                 "status": v["status"],
                 "since": v["since"] if v["status"] == "alert" else None,
+                "severity": v.get("severity") if v["status"] == "alert" else None,
             }
             for k, v in self._states.items()
         ]
@@ -178,6 +215,7 @@ class AlertStateManager:
                 "since": entry["since"],
                 "display_target": entry.get("display_target", target),
                 "fail_count": entry.get("fail_count", 0),
+                "severity": entry.get("severity"),
             })
         return rows
 
@@ -224,6 +262,7 @@ async def save_alert_state_to_db(
     row.since = _parse_since(entry["since"])
     row.display_target = entry["display_target"]
     row.fail_count = int(entry["fail_count"])
+    row.severity = entry.get("severity")
     row.updated_at = utcnow()
     await db.commit()
 
@@ -249,6 +288,7 @@ async def load_alert_state_from_db(
             since=since.isoformat(),
             display_target=row.display_target,
             fail_count=row.fail_count,
+            severity=row.severity,
         )
 
 
@@ -277,6 +317,7 @@ async def purge_stale_states(
     known_nas_aliases: set[str],
     known_upstream_ids: set[str] | None,
     known_route_ids: set[str] | None,
+    known_host_names: set[str] | None = None,
 ) -> list[tuple[str, str]]:
     """Drop alert states whose targets no longer exist.
 
@@ -309,6 +350,11 @@ async def purge_stale_states(
                 should_remove = True
             elif known_route_ids is not None:
                 should_remove = target not in known_route_ids
+        elif atype.startswith("server_"):
+            # Host signals (server_down / server_disk / server_cpu / ...): key by
+            # host name. Skip the purge when the registry could not be loaded.
+            if known_host_names is not None:
+                should_remove = target not in known_host_names
         elif atype == "error_rate":
             # Global error-rate monitoring was removed; drop any leftover state.
             should_remove = True

--- a/unibridge-service/app/services/server_monitor.py
+++ b/unibridge-service/app/services/server_monitor.py
@@ -314,6 +314,16 @@ async def evaluate_hosts(
         if disk_pct is not None:
             warn = _effective(host.disk_warn_pct, thresholds.disk_warn_pct)
             crit = _effective(host.disk_crit_pct, thresholds.disk_crit_pct)
+            alert_threshold = min(warn, crit)
+            if warn > crit:
+                logger.warning(
+                    "Invalid disk thresholds for host %s: warn %.1f > crit %.1f; "
+                    "using %.1f for alert health",
+                    name,
+                    warn,
+                    crit,
+                    alert_threshold,
+                )
             if disk_pct >= crit:
                 severity: str | None = "critical"
             elif disk_pct >= warn:
@@ -324,10 +334,10 @@ async def evaluate_hosts(
                 alert_type="server_disk",
                 target=name,
                 display=display,
-                is_healthy=disk_pct < warn,
+                is_healthy=disk_pct < alert_threshold,
                 severity=severity,
                 value=disk_pct,
-                threshold=warn,
+                threshold=alert_threshold,
                 message=(
                     f"Server '{display}' disk usage is {disk_pct:.1f}% "
                     f"(warn {warn:.0f}% / crit {crit:.0f}%)."

--- a/unibridge-service/app/services/server_monitor.py
+++ b/unibridge-service/app/services/server_monitor.py
@@ -1,0 +1,392 @@
+"""Server (host) monitoring via node_exporter metrics in Prometheus.
+
+Two responsibilities:
+
+1. **Service discovery** — render the :class:`~app.models.MonitoredHost`
+   registry into a Prometheus file-based service-discovery (``file_sd``) JSON
+   file, so Prometheus scrapes each registered host's node_exporter without a
+   config reload.
+2. **Evaluation** — query Prometheus for host signals (reachability, disk,
+   disk-fill forecast, CPU, memory) grouped by the ``host`` label and turn them
+   into :class:`HostSignal` results. The alert checker feeds these through the
+   shared :class:`~app.services.alert_state.AlertStateManager` /
+   ``dispatch_alert`` pipeline, exactly like the DB/NAS/route signals.
+
+All Prometheus access goes through :mod:`app.services.prometheus_client`, which
+raises on transport errors; :func:`evaluate_hosts` treats any query failure as
+"skip this cycle" rather than risk a false mass-``server_down`` storm when
+Prometheus itself is briefly unreachable.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from app.config import settings
+from app.services import prometheus_client
+
+logger = logging.getLogger(__name__)
+
+# Pseudo-filesystems that should never count toward host disk-capacity alerts.
+_FS_EXCLUDE = "tmpfs|overlay|squashfs|ramfs|devtmpfs"
+
+# All alert_type strings produced for host signals (keyed by host name).
+SERVER_ALERT_TYPES = (
+    "server_down",
+    "server_disk",
+    "server_disk_forecast",
+    "server_cpu",
+    "server_mem",
+)
+
+
+def _job() -> str:
+    return settings.NODE_EXPORTER_JOB
+
+
+# ── File-based service discovery ─────────────────────────────────────────────
+
+
+def build_targets(hosts: Iterable[Any]) -> list[dict[str, Any]]:
+    """Render enabled MonitoredHosts into Prometheus file_sd entries.
+
+    Each entry carries a ``host`` label (the friendly name, used as the alert
+    target) plus any user-defined labels stored as JSON on the host.
+    """
+    entries: list[dict[str, Any]] = []
+    for host in hosts:
+        if not getattr(host, "enabled", True):
+            continue
+        labels: dict[str, str] = {"host": host.name}
+        if host.labels:
+            try:
+                extra = json.loads(host.labels)
+            except (json.JSONDecodeError, TypeError):
+                extra = None
+            if isinstance(extra, dict):
+                for key, value in extra.items():
+                    # Never let a user label clobber the identifying host label.
+                    if str(key) == "host":
+                        continue
+                    labels[str(key)] = str(value)
+        entries.append({"targets": [host.address], "labels": labels})
+    return entries
+
+
+def _write_json_atomic(path: str, data: Any) -> None:
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+async def write_targets_file(hosts: Iterable[Any], path: str | None = None) -> None:
+    """Write the file_sd targets file atomically. Raises on I/O failure."""
+    target_path = path or settings.PROMETHEUS_FILE_SD_PATH
+    entries = build_targets(hosts)
+    await asyncio.to_thread(_write_json_atomic, target_path, entries)
+
+
+async def sync_targets_from_db(db) -> None:
+    """Reload the host registry and rewrite the file_sd targets (best-effort).
+
+    The database is the source of truth; a write failure here is logged but not
+    fatal — the next successful sync (a later CRUD op or boot reconcile) repairs
+    it. Callers should not depend on this raising.
+    """
+    from sqlalchemy import select
+
+    from app.models import MonitoredHost
+
+    result = await db.execute(select(MonitoredHost))
+    hosts = result.scalars().all()
+    try:
+        await write_targets_file(hosts)
+    except Exception as exc:  # noqa: BLE001 — best-effort reconcile
+        logger.warning(
+            "Failed to write Prometheus file_sd targets to %s: %s",
+            settings.PROMETHEUS_FILE_SD_PATH,
+            exc,
+        )
+
+
+# ── Threshold inputs ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class ServerThresholds:
+    """Global host thresholds (from AlertSettings); per-host columns override."""
+
+    disk_warn_pct: float = 80.0
+    disk_crit_pct: float = 90.0
+    cpu_warn_pct: float = 90.0
+    mem_warn_pct: float = 90.0
+    forecast_hours: float = 24.0
+
+
+@dataclass
+class HostSignal:
+    """One evaluated host signal, ready for the alert-state pipeline."""
+
+    alert_type: str
+    target: str          # host name (== ResourceOwner resource_id)
+    display: str
+    is_healthy: bool
+    severity: str | None
+    value: float | None
+    threshold: float | None
+    message: str
+    monitor_label: str
+
+
+# ── PromQL ───────────────────────────────────────────────────────────────────
+
+
+def _q_up() -> str:
+    return f'up{{job="{_job()}"}}'
+
+
+def _q_disk_pct() -> str:
+    j = _job()
+    return (
+        f'max by (host) (100 * (1 - '
+        f'node_filesystem_avail_bytes{{job="{j}",fstype!~"{_FS_EXCLUDE}"}} / '
+        f'node_filesystem_size_bytes{{job="{j}",fstype!~"{_FS_EXCLUDE}"}}))'
+    )
+
+
+def _q_disk_forecast(horizon_seconds: float) -> str:
+    j = _job()
+    return (
+        f'min by (host) (predict_linear('
+        f'node_filesystem_avail_bytes{{job="{j}",fstype!~"{_FS_EXCLUDE}"}}[6h], '
+        f'{int(horizon_seconds)}))'
+    )
+
+
+def _q_cpu_pct() -> str:
+    return (
+        f'100 * (1 - avg by (host) (rate('
+        f'node_cpu_seconds_total{{job="{_job()}",mode="idle"}}[5m])))'
+    )
+
+
+def _q_mem_pct() -> str:
+    j = _job()
+    return (
+        f'100 * (1 - node_memory_MemAvailable_bytes{{job="{j}"}} / '
+        f'node_memory_MemTotal_bytes{{job="{j}"}})'
+    )
+
+
+def _escape_label(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def metric_query(metric: str, host_name: str) -> str | None:
+    """PromQL for a single host's time series (used by the metrics dashboard)."""
+    j = _job()
+    sel = f'job="{j}",host="{_escape_label(host_name)}"'
+    if metric == "cpu":
+        return f'100 * (1 - avg by (host) (rate(node_cpu_seconds_total{{{sel},mode="idle"}}[5m])))'
+    if metric == "mem":
+        return (
+            f'100 * (1 - node_memory_MemAvailable_bytes{{{sel}}} / '
+            f'node_memory_MemTotal_bytes{{{sel}}})'
+        )
+    if metric == "disk":
+        return (
+            f'max by (host) (100 * (1 - '
+            f'node_filesystem_avail_bytes{{{sel},fstype!~"{_FS_EXCLUDE}"}} / '
+            f'node_filesystem_size_bytes{{{sel},fstype!~"{_FS_EXCLUDE}"}}))'
+        )
+    return None
+
+
+async def host_up_map() -> dict[str, bool] | None:
+    """Return {host_name: is_up} from Prometheus, or None if it is unreachable."""
+    try:
+        results = await prometheus_client.instant_query(_q_up())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not query host up status: %s", exc)
+        return None
+    return {host: value >= 1.0 for host, value in _map_by_host(results).items()}
+
+
+def _map_by_host(results: list[dict[str, Any]]) -> dict[str, float]:
+    """Collapse instant-query results into {host_label: value}, dropping NaN."""
+    out: dict[str, float] = {}
+    for item in results:
+        host = item.get("metric", {}).get("host")
+        if not host:
+            continue
+        try:
+            value = float(item.get("value", [0, "nan"])[1])
+        except (TypeError, ValueError, IndexError):
+            continue
+        if math.isnan(value):
+            continue
+        out[str(host)] = value
+    return out
+
+
+def _effective(override: float | None, default: float) -> float:
+    return float(override) if override is not None else float(default)
+
+
+# ── Evaluation ───────────────────────────────────────────────────────────────
+
+
+async def evaluate_hosts(
+    hosts: list[Any],
+    thresholds: ServerThresholds,
+) -> list[HostSignal]:
+    """Query Prometheus once per signal and build per-host results.
+
+    Returns an empty list (skip this cycle) if Prometheus is unreachable, so a
+    transient outage never produces a false ``server_down`` for every host.
+    """
+    enabled = [h for h in hosts if getattr(h, "enabled", True)]
+    if not enabled:
+        return []
+
+    forecast_on = thresholds.forecast_hours and thresholds.forecast_hours > 0
+    try:
+        up_map = _map_by_host(await prometheus_client.instant_query(_q_up()))
+        disk_map = _map_by_host(await prometheus_client.instant_query(_q_disk_pct()))
+        cpu_map = _map_by_host(await prometheus_client.instant_query(_q_cpu_pct()))
+        mem_map = _map_by_host(await prometheus_client.instant_query(_q_mem_pct()))
+        forecast_map: dict[str, float] = {}
+        if forecast_on:
+            forecast_map = _map_by_host(
+                await prometheus_client.instant_query(
+                    _q_disk_forecast(thresholds.forecast_hours * 3600.0)
+                )
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Server health check skipped (Prometheus query failed): %s", exc)
+        return []
+
+    signals: list[HostSignal] = []
+    for host in enabled:
+        name = host.name
+        display = name
+
+        # 1. Reachability. Absence from the up map == unreachable/not scraped.
+        is_up = up_map.get(name, 0.0) >= 1.0
+        signals.append(HostSignal(
+            alert_type="server_down",
+            target=name,
+            display=display,
+            is_healthy=is_up,
+            severity="critical" if not is_up else None,
+            value=None,
+            threshold=None,
+            message=(
+                f"Server '{display}' is reachable again."
+                if is_up else
+                f"Server '{display}' is unreachable (node_exporter scrape is down)."
+            ),
+            monitor_label="서버 상태",
+        ))
+        # When a host is down its other series are stale/absent — skip them so a
+        # single outage doesn't fan out into disk/cpu/mem alerts too.
+        if not is_up:
+            continue
+
+        # 2. Disk usage (worst filesystem), two-level severity.
+        disk_pct = disk_map.get(name)
+        if disk_pct is not None:
+            warn = _effective(host.disk_warn_pct, thresholds.disk_warn_pct)
+            crit = _effective(host.disk_crit_pct, thresholds.disk_crit_pct)
+            if disk_pct >= crit:
+                severity: str | None = "critical"
+            elif disk_pct >= warn:
+                severity = "warning"
+            else:
+                severity = None
+            signals.append(HostSignal(
+                alert_type="server_disk",
+                target=name,
+                display=display,
+                is_healthy=disk_pct < warn,
+                severity=severity,
+                value=disk_pct,
+                threshold=warn,
+                message=(
+                    f"Server '{display}' disk usage is {disk_pct:.1f}% "
+                    f"(warn {warn:.0f}% / crit {crit:.0f}%)."
+                ),
+                monitor_label="서버 디스크 사용률",
+            ))
+
+            # 3. Disk-fill forecast — proactive "will fill within N hours".
+            if forecast_on:
+                predicted = forecast_map.get(name)
+                if predicted is not None:
+                    will_fill = predicted < 0
+                    signals.append(HostSignal(
+                        alert_type="server_disk_forecast",
+                        target=name,
+                        display=display,
+                        is_healthy=not will_fill,
+                        severity="warning" if will_fill else None,
+                        value=None,
+                        threshold=thresholds.forecast_hours,
+                        message=(
+                            f"Server '{display}' disk is projected to fill within "
+                            f"{thresholds.forecast_hours:.0f}h at the current rate."
+                            if will_fill else
+                            f"Server '{display}' disk fill projection cleared."
+                        ),
+                        monitor_label="서버 디스크 예측",
+                    ))
+
+        # 4. CPU utilisation.
+        cpu_pct = cpu_map.get(name)
+        if cpu_pct is not None:
+            warn = _effective(host.cpu_warn_pct, thresholds.cpu_warn_pct)
+            signals.append(HostSignal(
+                alert_type="server_cpu",
+                target=name,
+                display=display,
+                is_healthy=cpu_pct < warn,
+                severity="warning" if cpu_pct >= warn else None,
+                value=cpu_pct,
+                threshold=warn,
+                message=f"Server '{display}' CPU usage is {cpu_pct:.1f}% (threshold {warn:.0f}%).",
+                monitor_label="서버 CPU 사용률",
+            ))
+
+        # 5. Memory utilisation.
+        mem_pct = mem_map.get(name)
+        if mem_pct is not None:
+            warn = _effective(host.mem_warn_pct, thresholds.mem_warn_pct)
+            signals.append(HostSignal(
+                alert_type="server_mem",
+                target=name,
+                display=display,
+                is_healthy=mem_pct < warn,
+                severity="warning" if mem_pct >= warn else None,
+                value=mem_pct,
+                threshold=warn,
+                message=f"Server '{display}' memory usage is {mem_pct:.1f}% (threshold {warn:.0f}%).",
+                monitor_label="서버 메모리 사용률",
+            ))
+
+    return signals

--- a/unibridge-service/tests/test_alerts_router.py
+++ b/unibridge-service/tests/test_alerts_router.py
@@ -401,6 +401,23 @@ async def test_update_alert_settings_rejects_explicit_numeric_nulls(client, admi
 
 
 @pytest.mark.asyncio
+async def test_update_alert_settings_rejects_invalid_disk_threshold_order(client, admin_token):
+    resp = await client.put(
+        "/admin/alerts/settings",
+        json={"server_disk_warn_pct": 95, "server_disk_crit_pct": 90},
+        headers=auth_header(admin_token),
+    )
+    assert resp.status_code == 422
+
+    partial_resp = await client.put(
+        "/admin/alerts/settings",
+        json={"server_disk_warn_pct": 95},
+        headers=auth_header(admin_token),
+    )
+    assert partial_resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_update_alert_settings_trigger_after_failures(client, admin_token):
     resp = await client.put(
         "/admin/alerts/settings",

--- a/unibridge-service/tests/test_server_monitor.py
+++ b/unibridge-service/tests/test_server_monitor.py
@@ -1,0 +1,189 @@
+"""Tests for server (host) monitoring: file_sd, evaluation, and state severity."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.services import server_monitor
+from app.services.server_monitor import ServerThresholds, build_targets, evaluate_hosts, metric_query
+from app.services.alert_state import AlertStateManager
+
+
+def _host(name="web1", address="10.0.0.1:9100", enabled=True, labels=None, **overrides):
+    return SimpleNamespace(
+        name=name, address=address, enabled=enabled, labels=labels,
+        disk_warn_pct=overrides.get("disk_warn_pct"),
+        disk_crit_pct=overrides.get("disk_crit_pct"),
+        cpu_warn_pct=overrides.get("cpu_warn_pct"),
+        mem_warn_pct=overrides.get("mem_warn_pct"),
+    )
+
+
+def _series(host, value):
+    return {"metric": {"host": host}, "value": [0, str(value)]}
+
+
+# ── file_sd ──────────────────────────────────────────────────────────────────
+
+def test_build_targets_skips_disabled_and_merges_labels():
+    hosts = [
+        _host("web1", "10.0.0.1:9100", labels='{"env":"prod"}'),
+        _host("web2", "10.0.0.2:9100", enabled=False),
+    ]
+    entries = build_targets(hosts)
+    assert len(entries) == 1
+    assert entries[0]["targets"] == ["10.0.0.1:9100"]
+    assert entries[0]["labels"] == {"host": "web1", "env": "prod"}
+
+
+def test_build_targets_user_label_cannot_clobber_host():
+    entries = build_targets([_host("web1", labels='{"host":"evil"}')])
+    assert entries[0]["labels"]["host"] == "web1"
+
+
+def test_metric_query_escapes_and_covers_metrics():
+    assert metric_query("cpu", "web1") is not None
+    assert 'host="web1"' in metric_query("disk", "web1")
+    assert metric_query("unknown", "web1") is None
+    assert '\\"' in metric_query("mem", 'a"b')
+
+
+# ── evaluation ───────────────────────────────────────────────────────────────
+
+def _patch_queries(mapping):
+    """Return an async side_effect mapping query substrings to result lists."""
+    async def fake(query, *a, **k):
+        for needle, results in mapping.items():
+            if needle in query:
+                return results
+        return []
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_disk_warning_and_critical_severity():
+    hosts = [_host("web1")]
+    th = ServerThresholds(disk_warn_pct=80, disk_crit_pct=90, forecast_hours=0)
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({
+            "up{": [_series("web1", 1)],
+            "node_filesystem_avail_bytes": [_series("web1", 85)],
+            "node_cpu_seconds_total": [_series("web1", 10)],
+            "node_memory_MemAvailable_bytes": [_series("web1", 10)],
+        })
+        signals = await evaluate_hosts(hosts, th)
+    disk = next(s for s in signals if s.alert_type == "server_disk")
+    assert disk.severity == "warning" and disk.is_healthy is False
+
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({
+            "up{": [_series("web1", 1)],
+            "node_filesystem_avail_bytes": [_series("web1", 95)],
+            "node_cpu_seconds_total": [_series("web1", 10)],
+            "node_memory_MemAvailable_bytes": [_series("web1", 10)],
+        })
+        signals = await evaluate_hosts(hosts, th)
+    disk = next(s for s in signals if s.alert_type == "server_disk")
+    assert disk.severity == "critical"
+
+
+@pytest.mark.asyncio
+async def test_down_host_skips_other_signals():
+    th = ServerThresholds(forecast_hours=0)
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({"up{": [_series("web1", 0)]})
+        signals = await evaluate_hosts([_host("web1")], th)
+    types = {s.alert_type for s in signals}
+    assert types == {"server_down"}
+    down = signals[0]
+    assert down.is_healthy is False and down.severity == "critical"
+
+
+@pytest.mark.asyncio
+async def test_missing_up_series_is_treated_as_down():
+    th = ServerThresholds(forecast_hours=0)
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({"up{": []})  # host not scraped yet
+        signals = await evaluate_hosts([_host("web1")], th)
+    assert signals[0].alert_type == "server_down" and signals[0].is_healthy is False
+
+
+@pytest.mark.asyncio
+async def test_per_host_threshold_override():
+    th = ServerThresholds(disk_warn_pct=80, disk_crit_pct=90, forecast_hours=0)
+    host = _host("web1", disk_warn_pct=50)
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({
+            "up{": [_series("web1", 1)],
+            "node_filesystem_avail_bytes": [_series("web1", 60)],
+        })
+        signals = await evaluate_hosts([host], th)
+    disk = next(s for s in signals if s.alert_type == "server_disk")
+    assert disk.is_healthy is False and disk.threshold == 50
+
+
+@pytest.mark.asyncio
+async def test_disk_forecast_fires_when_predicted_negative():
+    th = ServerThresholds(forecast_hours=24)
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({
+            "up{": [_series("web1", 1)],
+            "predict_linear": [_series("web1", -100)],
+            "node_filesystem_avail_bytes": [_series("web1", 50)],
+        })
+        signals = await evaluate_hosts([_host("web1")], th)
+    forecast = next(s for s in signals if s.alert_type == "server_disk_forecast")
+    assert forecast.is_healthy is False and forecast.severity == "warning"
+
+
+@pytest.mark.asyncio
+async def test_prometheus_failure_skips_cycle():
+    with patch.object(server_monitor.prometheus_client, "instant_query", new=AsyncMock(side_effect=RuntimeError("down"))):
+        signals = await evaluate_hosts([_host("web1")], ServerThresholds())
+    assert signals == []
+
+
+@pytest.mark.asyncio
+async def test_no_enabled_hosts_returns_empty():
+    assert await evaluate_hosts([_host(enabled=False)], ServerThresholds()) == []
+
+
+# ── state-machine: severity escalation + repeat ───────────────────────────────
+
+def test_severity_escalation_refires():
+    state = AlertStateManager()
+    # warning trigger (immediate, threshold=1)
+    assert state.update("server_disk", "web1", is_healthy=False, trigger_after_failures=1, severity="warning") == "triggered"
+    # still warning → no refire
+    assert state.update("server_disk", "web1", is_healthy=False, trigger_after_failures=1, severity="warning") is None
+    # escalates to critical → refire
+    assert state.update("server_disk", "web1", is_healthy=False, trigger_after_failures=1, severity="critical") == "triggered"
+    assert state.get_entry("server_disk", "web1")["severity"] == "critical"
+    # de-escalates → recorded but no refire
+    assert state.update("server_disk", "web1", is_healthy=False, trigger_after_failures=1, severity="warning") is None
+    assert state.get_entry("server_disk", "web1")["severity"] == "warning"
+
+
+def test_repeat_after_cycles_refires():
+    state = AlertStateManager()
+    assert state.update("server_cpu", "web1", is_healthy=False, trigger_after_failures=1, repeat_after_cycles=2) == "triggered"
+    assert state.update("server_cpu", "web1", is_healthy=False, trigger_after_failures=1, repeat_after_cycles=2) is None
+    assert state.update("server_cpu", "web1", is_healthy=False, trigger_after_failures=1, repeat_after_cycles=2) == "triggered"
+
+
+def test_resolve_clears_severity():
+    state = AlertStateManager()
+    state.update("server_disk", "web1", is_healthy=False, trigger_after_failures=1, severity="critical")
+    assert state.update("server_disk", "web1", is_healthy=True, trigger_after_failures=1) == "resolved"
+    assert state.get_entry("server_disk", "web1")["severity"] is None
+
+
+def test_binary_behaviour_unchanged_without_new_args():
+    """Existing alert types pass no severity/repeat → original semantics."""
+    state = AlertStateManager()
+    assert state.update("db_health", "x", is_healthy=False, trigger_after_failures=2) is None
+    assert state.update("db_health", "x", is_healthy=False, trigger_after_failures=2) == "triggered"
+    assert state.update("db_health", "x", is_healthy=False, trigger_after_failures=2) is None
+    assert state.update("db_health", "x", is_healthy=True, trigger_after_failures=2) == "resolved"

--- a/unibridge-service/tests/test_server_monitor.py
+++ b/unibridge-service/tests/test_server_monitor.py
@@ -125,6 +125,22 @@ async def test_per_host_threshold_override():
 
 
 @pytest.mark.asyncio
+async def test_disk_invalid_threshold_order_still_alerts_at_critical():
+    """A bad persisted warn/crit order must not suppress critical disk alerts."""
+    th = ServerThresholds(disk_warn_pct=95, disk_crit_pct=90, forecast_hours=0)
+    with patch.object(server_monitor.prometheus_client, "instant_query") as q:
+        q.side_effect = _patch_queries({
+            "up{": [_series("web1", 1)],
+            "node_filesystem_avail_bytes": [_series("web1", 92)],
+        })
+        signals = await evaluate_hosts([_host("web1")], th)
+    disk = next(s for s in signals if s.alert_type == "server_disk")
+    assert disk.severity == "critical"
+    assert disk.is_healthy is False
+    assert disk.threshold == 90
+
+
+@pytest.mark.asyncio
 async def test_disk_forecast_fires_when_predicted_negative():
     th = ServerThresholds(forecast_hours=24)
     with patch.object(server_monitor.prometheus_client, "instant_query") as q:

--- a/unibridge-service/tests/test_servers_router.py
+++ b/unibridge-service/tests/test_servers_router.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import pytest
 from unittest.mock import AsyncMock, patch
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.models import AlertState
 from tests.conftest import auth_header
 
 
@@ -64,6 +67,25 @@ async def test_invalid_address_and_name_rejected(client, admin_token):
 
 
 @pytest.mark.asyncio
+async def test_invalid_disk_threshold_order_rejected(client, admin_token):
+    h = auth_header(admin_token)
+    resp = await client.post(
+        "/admin/servers",
+        headers=h,
+        json={"name": "bad-disk", "address": "1.2.3.4:9100", "disk_warn_pct": 95, "disk_crit_pct": 90},
+    )
+    assert resp.status_code == 422
+
+    # A single override is also validated against the global default critical threshold.
+    resp = await client.post(
+        "/admin/servers",
+        headers=h,
+        json={"name": "bad-effective", "address": "1.2.3.5:9100", "disk_warn_pct": 95},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_requires_permission(client, user_token):
     """The seeded 'user' role lacks servers.read/write."""
     h = auth_header(user_token)
@@ -79,3 +101,34 @@ async def test_test_endpoint_reports_status(client, admin_token):
     with patch("app.routers.servers.server_monitor.host_up_map", new=AsyncMock(return_value={"web9": True})):
         resp = await client.post(f"/admin/servers/{host_id}/test", headers=h)
     assert resp.status_code == 200 and resp.json()["status"] == "up"
+
+
+@pytest.mark.asyncio
+async def test_disabling_server_persists_alert_state_cleanup(client, admin_token, seeded_db):
+    h = auth_header(admin_token)
+    created = await client.post(
+        "/admin/servers",
+        headers=h,
+        json={"name": "web-state", "address": "1.2.3.4:9100"},
+    )
+    assert created.status_code == 201, created.text
+    host_id = created.json()["id"]
+
+    session_factory = async_sessionmaker(seeded_db, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as db:
+        db.add(AlertState(alert_type="server_down", target="web-state", status="alert"))
+        await db.commit()
+
+    resp = await client.put(f"/admin/servers/{host_id}", headers=h, json={"enabled": False})
+    assert resp.status_code == 200, resp.text
+
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                select(AlertState).where(
+                    AlertState.alert_type == "server_down",
+                    AlertState.target == "web-state",
+                )
+            )
+        ).scalar_one_or_none()
+    assert row is None

--- a/unibridge-service/tests/test_servers_router.py
+++ b/unibridge-service/tests/test_servers_router.py
@@ -1,0 +1,81 @@
+"""Tests for the monitored-server registry router (/admin/servers)."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from tests.conftest import auth_header
+
+
+@pytest.fixture(autouse=True)
+def _no_prometheus_or_filesd():
+    """Isolate the router from Prometheus and the file_sd writer."""
+    with patch("app.routers.servers.server_monitor.sync_targets_from_db", new=AsyncMock()), \
+         patch("app.routers.servers.server_monitor.host_up_map", new=AsyncMock(return_value={})):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_create_list_update_delete(client, admin_token):
+    h = auth_header(admin_token)
+
+    # create
+    resp = await client.post("/admin/servers", headers=h, json={
+        "name": "web1", "address": "10.0.0.5:9100", "description": "edge",
+        "disk_warn_pct": 70,
+    })
+    assert resp.status_code == 201, resp.text
+    host_id = resp.json()["id"]
+    assert resp.json()["disk_warn_pct"] == 70
+
+    # list (status comes from the mocked up_map → unknown)
+    resp = await client.get("/admin/servers", headers=h)
+    assert resp.status_code == 200
+    assert [r["name"] for r in resp.json()] == ["web1"]
+
+    # update threshold + disable
+    resp = await client.put(f"/admin/servers/{host_id}", headers=h, json={"cpu_warn_pct": 85, "enabled": False})
+    assert resp.status_code == 200
+    assert resp.json()["cpu_warn_pct"] == 85 and resp.json()["enabled"] is False
+
+    # delete
+    resp = await client.delete(f"/admin/servers/{host_id}", headers=h)
+    assert resp.status_code == 204
+
+    resp = await client.get("/admin/servers", headers=h)
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_name_conflicts(client, admin_token):
+    h = auth_header(admin_token)
+    body = {"name": "dup", "address": "1.2.3.4:9100"}
+    assert (await client.post("/admin/servers", headers=h, json=body)).status_code == 201
+    resp = await client.post("/admin/servers", headers=h, json=body)
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_invalid_address_and_name_rejected(client, admin_token):
+    h = auth_header(admin_token)
+    assert (await client.post("/admin/servers", headers=h, json={"name": "x", "address": "no-port"})).status_code == 422
+    assert (await client.post("/admin/servers", headers=h, json={"name": "bad name", "address": "1.2.3.4:9100"})).status_code == 422
+    assert (await client.post("/admin/servers", headers=h, json={"name": "y", "address": "1.2.3.4:99999"})).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_requires_permission(client, user_token):
+    """The seeded 'user' role lacks servers.read/write."""
+    h = auth_header(user_token)
+    assert (await client.get("/admin/servers", headers=h)).status_code == 403
+    assert (await client.post("/admin/servers", headers=h, json={"name": "z", "address": "1.2.3.4:9100"})).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_reports_status(client, admin_token):
+    h = auth_header(admin_token)
+    created = await client.post("/admin/servers", headers=h, json={"name": "web9", "address": "1.2.3.4:9100"})
+    host_id = created.json()["id"]
+    with patch("app.routers.servers.server_monitor.host_up_map", new=AsyncMock(return_value={"web9": True})):
+        resp = await client.post(f"/admin/servers/{host_id}/test", headers=h)
+    assert resp.status_code == 200 and resp.json()["status"] == "up"

--- a/unibridge-ui/src/App.tsx
+++ b/unibridge-ui/src/App.tsx
@@ -29,6 +29,8 @@ const S3Connections = lazy(() => import('./pages/S3Connections'));
 const S3Browser = lazy(() => import('./pages/S3Browser'));
 const NasConnections = lazy(() => import('./pages/NasConnections'));
 const NasBrowser = lazy(() => import('./pages/NasBrowser'));
+const Servers = lazy(() => import('./pages/Servers'));
+const ServerDetail = lazy(() => import('./pages/ServerDetail'));
 
 export function ProtectedRoute({ permission, children }: { permission: string | string[]; children: React.ReactNode }) {
   const { t } = useTranslation();
@@ -88,6 +90,8 @@ function App() {
           <Route path="/s3/browse/:alias" element={<ProtectedRoute permission="s3.browse"><S3Browser /></ProtectedRoute>} />
           <Route path="/nas" element={<ProtectedRoute permission="nas.connections.read"><NasConnections /></ProtectedRoute>} />
           <Route path="/nas/browse/:alias" element={<ProtectedRoute permission="nas.browse"><NasBrowser /></ProtectedRoute>} />
+          <Route path="/servers" element={<ProtectedRoute permission="servers.read"><Servers /></ProtectedRoute>} />
+          <Route path="/servers/:id" element={<ProtectedRoute permission="servers.read"><ServerDetail /></ProtectedRoute>} />
           <Route path="/gateway/routes" element={<ProtectedRoute permission="gateway.routes.read"><GatewayRoutes /></ProtectedRoute>} />
           <Route path="/gateway/routes/new" element={<ProtectedRoute permission="gateway.routes.write"><GatewayRouteForm /></ProtectedRoute>} />
           <Route path="/gateway/routes/:id/edit" element={<ProtectedRoute permission="gateway.routes.write"><GatewayRouteForm /></ProtectedRoute>} />

--- a/unibridge-ui/src/api/client.ts
+++ b/unibridge-ui/src/api/client.ts
@@ -1071,6 +1071,12 @@ export interface AlertSettings {
   route_error_threshold_pct: number;
   check_interval_seconds: number;
   trigger_after_failures: number;
+  server_disk_warn_pct?: number;
+  server_disk_crit_pct?: number;
+  server_cpu_warn_pct?: number;
+  server_mem_warn_pct?: number;
+  server_disk_forecast_hours?: number;
+  repeat_alert_after_cycles?: number;
   updated_at?: string | null;
 }
 
@@ -1087,6 +1093,7 @@ export interface AlertHistoryEntry {
   channel_id: number | null;
   alert_type: 'triggered' | 'resolved';
   target: string;
+  severity?: string | null;
   message: string;
   recipients: string[] | null;
   sent_at: string;
@@ -1099,6 +1106,7 @@ export interface AlertStatus {
   type: string;
   status: 'ok' | 'alert';
   since: string | null;
+  severity?: string | null;
 }
 
 // Channels
@@ -1184,6 +1192,73 @@ export async function getAlertHistory(params?: {
 
 export async function getAlertStatus(): Promise<AlertStatus[]> {
   const { data } = await client.get('/admin/alerts/status');
+  return data;
+}
+
+/* ── Monitored servers (hosts) ── */
+
+export interface MonitoredServer {
+  id: number;
+  name: string;
+  address: string;
+  enabled: boolean;
+  description: string;
+  labels: Record<string, string> | null;
+  disk_warn_pct: number | null;
+  disk_crit_pct: number | null;
+  cpu_warn_pct: number | null;
+  mem_warn_pct: number | null;
+  status?: 'up' | 'down' | 'unknown' | 'disabled' | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface MonitoredServerInput {
+  name?: string;
+  address?: string;
+  enabled?: boolean;
+  description?: string;
+  labels?: Record<string, string> | null;
+  disk_warn_pct?: number | null;
+  disk_crit_pct?: number | null;
+  cpu_warn_pct?: number | null;
+  mem_warn_pct?: number | null;
+}
+
+export interface ServerMetricSeries {
+  metric: 'cpu' | 'mem' | 'disk';
+  points: Array<{ t: number; v: number | null }>;
+}
+
+export async function getServers(): Promise<MonitoredServer[]> {
+  const { data } = await client.get('/admin/servers');
+  return data;
+}
+
+export async function createServer(body: MonitoredServerInput): Promise<MonitoredServer> {
+  const { data } = await client.post('/admin/servers', body);
+  return data;
+}
+
+export async function updateServer(id: number, body: MonitoredServerInput): Promise<MonitoredServer> {
+  const { data } = await client.put(`/admin/servers/${id}`, body);
+  return data;
+}
+
+export async function deleteServer(id: number): Promise<void> {
+  await client.delete(`/admin/servers/${id}`);
+}
+
+export async function testServer(id: number): Promise<{ status: string; detail: string | null }> {
+  const { data } = await client.post(`/admin/servers/${id}/test`);
+  return data;
+}
+
+export async function getServerMetrics(
+  id: number,
+  params: { duration?: string; step?: string } = {},
+): Promise<ServerMetricSeries[]> {
+  const { data } = await client.get(`/admin/servers/${id}/metrics`, { params });
   return data;
 }
 

--- a/unibridge-ui/src/components/navItems.ts
+++ b/unibridge-ui/src/components/navItems.ts
@@ -28,6 +28,7 @@ export const navItems: NavItem[] = [
   { to: '/gateway/upstreams', labelKey: 'nav.gatewayUpstreams', icon: 'Gateway Upstreams', section: 'gateway', permission: 'gateway.upstreams.read' },
   { to: '/gateway/monitoring', labelKey: 'nav.gatewayMonitoring', icon: 'Gateway Monitoring', section: 'gateway', permission: ['gateway.monitoring.read', 'gateway.monitoring.self'] },
   { to: '/llm/monitoring', labelKey: 'nav.llmMonitoring', icon: 'LLM Monitoring', section: 'llm', permission: 'gateway.monitoring.read' },
+  { to: '/servers', labelKey: 'nav.servers', icon: 'Gateway Monitoring', section: 'servers', permission: 'servers.read' },
   { to: '/api-keys', labelKey: 'nav.apiKeys', icon: 'API Keys', section: 'access', permission: 'apikeys.read' },
   { to: '/my-api-key', labelKey: 'nav.myApiKey', icon: 'API Keys', section: 'access', permission: 'apikeys.self' },
   { to: '/roles', labelKey: 'nav.roles', icon: 'Roles', section: 'admin', permission: 'admin.roles.read' },

--- a/unibridge-ui/src/locales/en.json
+++ b/unibridge-ui/src/locales/en.json
@@ -803,7 +803,7 @@
     "empty": "No servers registered yet. Add one running node_exporter to start monitoring.",
     "name": "Name",
     "address": "node_exporter address",
-    "addressHint": "host:port of the node_exporter agent (default port 9100).",
+    "addressHint": "host:port of the node_exporter agent (default port 39100).",
     "description": "Description",
     "enabled": "Enabled (scraped & monitored)",
     "statusLabel": "Status",

--- a/unibridge-ui/src/locales/en.json
+++ b/unibridge-ui/src/locales/en.json
@@ -20,7 +20,8 @@
     "alertHistory": "Alert History",
     "llmMonitoring": "LLM Monitoring",
     "s3Connections": "S3 Storage",
-    "nasConnections": "NAS Storage"
+    "nasConnections": "NAS Storage",
+    "servers": "Servers"
   },
   "common": {
     "save": "Save",
@@ -772,12 +773,54 @@
     "varDesc_recipients_json": "Rendered JSON array of mail recipient items",
     "varDesc_rate": "Current error rate (used in error-rate-based alerts)",
     "varDesc_threshold": "Threshold value configured in the rule",
-    "varDesc_rule_name": "Alert rule name"
+    "varDesc_rule_name": "Alert rule name",
+    "typeServerDown": "Server down",
+    "typeServerDisk": "Server disk",
+    "typeServerDiskForecast": "Disk forecast",
+    "typeServerCpu": "Server CPU",
+    "typeServerMem": "Server memory",
+    "severityCritical": "Critical",
+    "severityWarning": "Warning",
+    "serverThresholdsTitle": "Server thresholds (global defaults)",
+    "serverDiskWarn": "Disk warn %",
+    "serverDiskCrit": "Disk critical %",
+    "serverCpuWarn": "CPU warn %",
+    "serverMemWarn": "Memory warn %",
+    "serverForecastHours": "Disk-fill forecast (hours, 0=off)",
+    "repeatAfterCycles": "Re-notify every N cycles (0=once)"
   },
   "pending": {
     "title": "Awaiting approval",
     "message": "Your registration was received. An administrator must approve your account before you can use the service.",
     "account": "Signed in as {{username}}",
     "recheck": "Check again"
+  },
+  "servers": {
+    "title": "Servers",
+    "subtitle": "Monitor host CPU, memory, and disk via node_exporter, with proactive alerts.",
+    "add": "Add server",
+    "edit": "Edit server",
+    "empty": "No servers registered yet. Add one running node_exporter to start monitoring.",
+    "name": "Name",
+    "address": "node_exporter address",
+    "addressHint": "host:port of the node_exporter agent (default port 9100).",
+    "description": "Description",
+    "enabled": "Enabled (scraped & monitored)",
+    "statusLabel": "Status",
+    "disabled": "disabled",
+    "test": "Test",
+    "deleteConfirm": "Delete server \"{{name}}\"?",
+    "deleteFailed": "Failed to delete server",
+    "saveFailed": "Failed to save server",
+    "thresholdsTitle": "Per-host thresholds (optional)",
+    "thresholdsHint": "Leave blank to inherit the global defaults from Alert settings.",
+    "diskWarn": "Disk warn %",
+    "diskCrit": "Disk critical %",
+    "cpuWarn": "CPU warn %",
+    "memWarn": "Memory warn %",
+    "metric_cpu": "CPU usage (%)",
+    "metric_mem": "Memory usage (%)",
+    "metric_disk": "Disk usage (%)",
+    "noMetricData": "No metric data in this window."
   }
 }

--- a/unibridge-ui/src/locales/ko.json
+++ b/unibridge-ui/src/locales/ko.json
@@ -803,7 +803,7 @@
     "empty": "등록된 서버가 없습니다. node_exporter가 실행 중인 서버를 추가하세요.",
     "name": "이름",
     "address": "node_exporter 주소",
-    "addressHint": "node_exporter 에이전트의 host:port (기본 포트 9100).",
+    "addressHint": "node_exporter 에이전트의 host:port (기본 포트 39100).",
     "description": "설명",
     "enabled": "활성화 (수집·모니터링)",
     "statusLabel": "상태",

--- a/unibridge-ui/src/locales/ko.json
+++ b/unibridge-ui/src/locales/ko.json
@@ -20,7 +20,8 @@
     "alertHistory": "알림 이력",
     "llmMonitoring": "LLM 모니터링",
     "s3Connections": "S3 스토리지",
-    "nasConnections": "NAS 스토리지"
+    "nasConnections": "NAS 스토리지",
+    "servers": "서버 모니터링"
   },
   "common": {
     "save": "저장",
@@ -772,12 +773,54 @@
     "varDesc_recipients_json": "메일 수신자 항목으로 렌더링된 JSON 배열",
     "varDesc_rate": "현재 에러율 (에러율 기반 알림에서 사용)",
     "varDesc_threshold": "임계값 (규칙에 설정된 기준값)",
-    "varDesc_rule_name": "알림 규칙 이름"
+    "varDesc_rule_name": "알림 규칙 이름",
+    "typeServerDown": "서버 다운",
+    "typeServerDisk": "서버 디스크",
+    "typeServerDiskForecast": "디스크 예측",
+    "typeServerCpu": "서버 CPU",
+    "typeServerMem": "서버 메모리",
+    "severityCritical": "심각",
+    "severityWarning": "경고",
+    "serverThresholdsTitle": "서버 임계값 (전역 기본값)",
+    "serverDiskWarn": "디스크 경고 %",
+    "serverDiskCrit": "디스크 심각 %",
+    "serverCpuWarn": "CPU 경고 %",
+    "serverMemWarn": "메모리 경고 %",
+    "serverForecastHours": "디스크 소진 예측(시간, 0=끔)",
+    "repeatAfterCycles": "N주기마다 재알림(0=1회)"
   },
   "pending": {
     "title": "가입 승인 대기 중",
     "message": "가입 신청이 접수되었습니다. 관리자가 계정을 승인해야 서비스를 이용할 수 있습니다.",
     "account": "{{username}} 계정으로 로그인됨",
     "recheck": "다시 확인"
+  },
+  "servers": {
+    "title": "서버 모니터링",
+    "subtitle": "node_exporter로 호스트 CPU·메모리·디스크를 모니터링하고 사전 알림을 보냅니다.",
+    "add": "서버 추가",
+    "edit": "서버 편집",
+    "empty": "등록된 서버가 없습니다. node_exporter가 실행 중인 서버를 추가하세요.",
+    "name": "이름",
+    "address": "node_exporter 주소",
+    "addressHint": "node_exporter 에이전트의 host:port (기본 포트 9100).",
+    "description": "설명",
+    "enabled": "활성화 (수집·모니터링)",
+    "statusLabel": "상태",
+    "disabled": "비활성",
+    "test": "테스트",
+    "deleteConfirm": "서버 \"{{name}}\"을(를) 삭제할까요?",
+    "deleteFailed": "서버 삭제 실패",
+    "saveFailed": "서버 저장 실패",
+    "thresholdsTitle": "호스트별 임계값 (선택)",
+    "thresholdsHint": "비워두면 알림 설정의 전역 기본값을 따릅니다.",
+    "diskWarn": "디스크 경고 %",
+    "diskCrit": "디스크 심각 %",
+    "cpuWarn": "CPU 경고 %",
+    "memWarn": "메모리 경고 %",
+    "metric_cpu": "CPU 사용률 (%)",
+    "metric_mem": "메모리 사용률 (%)",
+    "metric_disk": "디스크 사용률 (%)",
+    "noMetricData": "이 구간에 메트릭 데이터가 없습니다."
   }
 }

--- a/unibridge-ui/src/pages/AlertStatus.tsx
+++ b/unibridge-ui/src/pages/AlertStatus.tsx
@@ -13,8 +13,19 @@ function typeLabel(t: (k: string) => string, type: string): string {
     upstream_health: t('alerts.typeUpstreamHealth'),
     error_rate: t('alerts.typeErrorRate'),
     route_error_rate: t('alerts.typeRouteErrorRate'),
+    server_down: t('alerts.typeServerDown'),
+    server_disk: t('alerts.typeServerDisk'),
+    server_disk_forecast: t('alerts.typeServerDiskForecast'),
+    server_cpu: t('alerts.typeServerCpu'),
+    server_mem: t('alerts.typeServerMem'),
   };
   return map[type] ?? type;
+}
+
+function severityLabel(t: (k: string) => string, severity: string | null): string {
+  if (severity === 'critical') return t('alerts.severityCritical');
+  if (severity === 'warning') return t('alerts.severityWarning');
+  return '';
 }
 
 function formatDuration(ts: string | null): string {
@@ -112,6 +123,21 @@ function AlertStatus() {
                           >
                             {typeLabel(t, e.type)}
                           </span>
+                          {e.severity && (
+                            <span
+                              style={{
+                                marginLeft: 6,
+                                padding: '1px 8px',
+                                borderRadius: 999,
+                                fontSize: '0.72rem',
+                                fontWeight: 600,
+                                color: '#fff',
+                                background: e.severity === 'critical' ? 'var(--accent-red, #d23b3b)' : 'var(--accent-yellow, #d29a3b)',
+                              }}
+                            >
+                              {severityLabel(t, e.severity)}
+                            </span>
+                          )}
                         </td>
                         <td className="cell-target">{e.target || '*'}</td>
                         <td className="cell-timestamp">{formatKST(e.since)}</td>

--- a/unibridge-ui/src/pages/ServerDetail.tsx
+++ b/unibridge-ui/src/pages/ServerDetail.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import { getServers, getServerMetrics, type ServerMetricSeries } from '../api/client';
+import { useChartTheme } from '../components/useChartTheme';
+import './Connections.css';
+import './Servers.css';
+
+const DURATIONS: Array<{ key: string; step: string }> = [
+  { key: '1h', step: '60s' },
+  { key: '6h', step: '120s' },
+  { key: '24h', step: '300s' },
+];
+
+const METRIC_COLORS: Record<string, 'blue' | 'green' | 'yellow'> = {
+  cpu: 'blue',
+  mem: 'green',
+  disk: 'yellow',
+};
+
+function toChartData(series: ServerMetricSeries) {
+  return series.points.map((p) => ({
+    time: new Date(p.t * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    value: p.v,
+  }));
+}
+
+function ServerDetail() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const params = useParams();
+  const id = Number(params.id);
+  const theme = useChartTheme();
+  const [duration, setDuration] = useState(DURATIONS[0]);
+
+  const serversQuery = useQuery({ queryKey: ['servers'], queryFn: getServers });
+  const server = (serversQuery.data ?? []).find((s) => s.id === id);
+
+  const metricsQuery = useQuery({
+    queryKey: ['server-metrics', id, duration.key],
+    queryFn: () => getServerMetrics(id, { duration: duration.key, step: duration.step }),
+    enabled: Number.isFinite(id),
+    refetchInterval: 30_000,
+  });
+
+  const series = metricsQuery.data ?? [];
+
+  return (
+    <div className="connections">
+      <div className="page-header">
+        <div>
+          <button className="link-button" onClick={() => navigate('/servers')}>&larr; {t('servers.title')}</button>
+          <h1>{server?.name ?? `#${id}`}</h1>
+          <p className="page-subtitle">{server?.address}</p>
+        </div>
+        <div className="server-detail-controls">
+          {DURATIONS.map((d) => (
+            <button
+              key={d.key}
+              className={`btn btn-sm${d.key === duration.key ? ' btn-primary' : ''}`}
+              onClick={() => setDuration(d)}
+            >
+              {d.key}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {metricsQuery.isLoading && <div className="loading-message">{t('common.loading')}</div>}
+      {metricsQuery.isError && <div className="error-banner">{t('common.errorOccurred')}</div>}
+
+      {!metricsQuery.isLoading && !metricsQuery.isError && (
+        <div className="server-charts">
+          {series.map((s) => {
+            const color = theme[METRIC_COLORS[s.metric] ?? 'blue'];
+            const data = toChartData(s);
+            return (
+              <div className="server-chart-card" key={s.metric}>
+                <h3>{t(`servers.metric_${s.metric}`)}</h3>
+                <div className="server-chart-body">
+                  {data.length === 0 ? (
+                    <div className="empty-state empty-state--small"><p>{t('servers.noMetricData')}</p></div>
+                  ) : (
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={data}>
+                        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />
+                        <XAxis dataKey="time" stroke={theme.axis} tick={{ fontSize: 11 }} minTickGap={40} />
+                        <YAxis stroke={theme.axis} tick={{ fontSize: 11 }} domain={[0, 100]} unit="%" />
+                        <Tooltip
+                          contentStyle={{ background: theme.tooltipBg, border: `1px solid ${theme.tooltipBorder}` }}
+                          formatter={(value) => {
+                            const n = Number(value);
+                            return Number.isFinite(n) ? `${n.toFixed(1)}%` : '—';
+                          }}
+                        />
+                        <Line type="monotone" dataKey="value" stroke={color} strokeWidth={2} dot={false} connectNulls />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ServerDetail;

--- a/unibridge-ui/src/pages/Servers.css
+++ b/unibridge-ui/src/pages/Servers.css
@@ -1,0 +1,45 @@
+.status-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.status-badge--ok { background: var(--accent-green, #1f8a4c); color: #fff; }
+.status-badge--alert { background: var(--accent-red, #d23b3b); color: #fff; }
+.status-badge--unknown { background: var(--bg-tertiary, #555); color: var(--text-secondary, #ddd); }
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent-blue, #3b82f6);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.form-section-label {
+  margin: 1rem 0 0.25rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+.form-hint { color: var(--text-tertiary, #888); font-size: 0.8rem; margin: 0.15rem 0 0.5rem; }
+
+.server-charts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+.server-chart-card {
+  background: var(--bg-secondary, #1c1c1c);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 8px;
+  padding: 1rem;
+}
+.server-chart-card h3 { margin: 0 0 0.75rem; font-size: 0.95rem; }
+.server-chart-body { width: 100%; height: 220px; }
+
+.server-detail-controls { display: flex; gap: 0.5rem; align-items: center; }

--- a/unibridge-ui/src/pages/Servers.tsx
+++ b/unibridge-ui/src/pages/Servers.tsx
@@ -248,7 +248,7 @@ function Servers() {
               <input
                 value={form.address}
                 onChange={(e) => setForm({ ...form, address: e.target.value })}
-                placeholder="10.0.0.5:9100"
+                placeholder="10.0.0.5:39100"
                 required
               />
               <small className="form-hint">{t('servers.addressHint')}</small>

--- a/unibridge-ui/src/pages/Servers.tsx
+++ b/unibridge-ui/src/pages/Servers.tsx
@@ -1,0 +1,303 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  getServers,
+  createServer,
+  updateServer,
+  deleteServer,
+  testServer,
+  type MonitoredServer,
+  type MonitoredServerInput,
+} from '../api/client';
+import ResourceModal from '../components/ResourceModal';
+import { useToast } from '../components/useToast';
+import { useCanWrite } from '../components/useCanWrite';
+import './Connections.css';
+import './Servers.css';
+
+interface FormState {
+  name: string;
+  address: string;
+  description: string;
+  enabled: boolean;
+  disk_warn_pct: string;
+  disk_crit_pct: string;
+  cpu_warn_pct: string;
+  mem_warn_pct: string;
+}
+
+const emptyForm: FormState = {
+  name: '', address: '', description: '', enabled: true,
+  disk_warn_pct: '', disk_crit_pct: '', cpu_warn_pct: '', mem_warn_pct: '',
+};
+
+function pctOrNull(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+function numToStr(value: number | null): string {
+  return value == null ? '' : String(value);
+}
+
+function statusClass(status?: string | null): string {
+  if (status === 'up') return 'status-badge--ok';
+  if (status === 'down') return 'status-badge--alert';
+  return 'status-badge--unknown';
+}
+
+function Servers() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
+  const canWrite = useCanWrite('servers.write');
+
+  const [showModal, setShowModal] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState<FormState>({ ...emptyForm });
+
+  const serversQuery = useQuery({
+    queryKey: ['servers'],
+    queryFn: getServers,
+    refetchInterval: 30_000,
+  });
+
+  function closeModal() {
+    setShowModal(false);
+    setEditingId(null);
+    setForm({ ...emptyForm });
+  }
+
+  function invalidate() {
+    queryClient.invalidateQueries({ queryKey: ['servers'] });
+  }
+
+  const createMutation = useMutation({
+    mutationFn: (data: MonitoredServerInput) => createServer(data),
+    onSuccess: () => { invalidate(); closeModal(); },
+    onError: () => addToast({ type: 'error', title: t('servers.saveFailed') }),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: MonitoredServerInput }) => updateServer(id, data),
+    onSuccess: () => { invalidate(); closeModal(); },
+    onError: () => addToast({ type: 'error', title: t('servers.saveFailed') }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteServer(id),
+    onSuccess: invalidate,
+    onError: () => addToast({ type: 'error', title: t('servers.deleteFailed') }),
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (id: number) => testServer(id),
+    onSuccess: (data) => addToast({
+      type: data.status === 'up' ? 'success' : 'error',
+      title: `${t('servers.statusLabel')}: ${data.status}`,
+      message: data.detail ?? undefined,
+    }),
+  });
+
+  function openCreate() {
+    setForm({ ...emptyForm });
+    setEditingId(null);
+    setShowModal(true);
+  }
+
+  function openEdit(server: MonitoredServer) {
+    setForm({
+      name: server.name,
+      address: server.address,
+      description: server.description ?? '',
+      enabled: server.enabled,
+      disk_warn_pct: numToStr(server.disk_warn_pct),
+      disk_crit_pct: numToStr(server.disk_crit_pct),
+      cpu_warn_pct: numToStr(server.cpu_warn_pct),
+      mem_warn_pct: numToStr(server.mem_warn_pct),
+    });
+    setEditingId(server.id);
+    setShowModal(true);
+  }
+
+  function submit() {
+    const thresholds = {
+      disk_warn_pct: pctOrNull(form.disk_warn_pct),
+      disk_crit_pct: pctOrNull(form.disk_crit_pct),
+      cpu_warn_pct: pctOrNull(form.cpu_warn_pct),
+      mem_warn_pct: pctOrNull(form.mem_warn_pct),
+    };
+    if (editingId == null) {
+      createMutation.mutate({
+        name: form.name.trim(),
+        address: form.address.trim(),
+        description: form.description.trim(),
+        enabled: form.enabled,
+        ...thresholds,
+      });
+    } else {
+      updateMutation.mutate({
+        id: editingId,
+        data: {
+          address: form.address.trim(),
+          description: form.description.trim(),
+          enabled: form.enabled,
+          ...thresholds,
+        },
+      });
+    }
+  }
+
+  const servers = serversQuery.data ?? [];
+  const saving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="connections">
+      <div className="page-header">
+        <div>
+          <h1>{t('servers.title')}</h1>
+          <p className="page-subtitle">{t('servers.subtitle')}</p>
+        </div>
+        {canWrite && (
+          <button className="btn btn-primary" onClick={openCreate}>{t('servers.add')}</button>
+        )}
+      </div>
+
+      {serversQuery.isLoading && <div className="loading-message">{t('common.loading')}</div>}
+      {serversQuery.isError && <div className="error-banner">{t('common.errorOccurred')}</div>}
+
+      {!serversQuery.isLoading && !serversQuery.isError && (
+        servers.length === 0 ? (
+          <div className="empty-state"><p>{t('servers.empty')}</p></div>
+        ) : (
+          <div className="table-container">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>{t('servers.statusLabel')}</th>
+                  <th>{t('servers.name')}</th>
+                  <th>{t('servers.address')}</th>
+                  <th>{t('servers.description')}</th>
+                  <th>{t('common.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {servers.map((s) => (
+                  <tr key={s.id}>
+                    <td>
+                      <span className={`status-badge ${statusClass(s.enabled ? s.status : 'disabled')}`}>
+                        {s.enabled ? (s.status ?? 'unknown') : t('servers.disabled')}
+                      </span>
+                    </td>
+                    <td>
+                      <button className="link-button" onClick={() => navigate(`/servers/${s.id}`)}>{s.name}</button>
+                    </td>
+                    <td className="cell-target">{s.address}</td>
+                    <td>{s.description}</td>
+                    <td className="cell-actions">
+                      <button className="btn btn-sm" onClick={() => testMutation.mutate(s.id)} disabled={testMutation.isPending}>
+                        {t('servers.test')}
+                      </button>
+                      {canWrite && (
+                        <>
+                          <button className="btn btn-sm" onClick={() => openEdit(s)}>{t('common.edit')}</button>
+                          <button
+                            className="btn btn-sm btn-danger"
+                            onClick={() => { if (window.confirm(t('servers.deleteConfirm', { name: s.name }))) deleteMutation.mutate(s.id); }}
+                          >
+                            {t('common.delete')}
+                          </button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      )}
+
+      {showModal && (
+        <ResourceModal
+          title={editingId == null ? t('servers.add') : t('servers.edit')}
+          onClose={closeModal}
+          closeLabel={t('common.cancel')}
+        >
+          <form
+            className="modal-body"
+            onSubmit={(e) => { e.preventDefault(); submit(); }}
+          >
+            <div className="form-group">
+              <label>{t('servers.name')}</label>
+              <input
+                value={form.name}
+                disabled={editingId != null}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="web-prod-1"
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label>{t('servers.address')}</label>
+              <input
+                value={form.address}
+                onChange={(e) => setForm({ ...form, address: e.target.value })}
+                placeholder="10.0.0.5:9100"
+                required
+              />
+              <small className="form-hint">{t('servers.addressHint')}</small>
+            </div>
+            <div className="form-group">
+              <label>{t('servers.description')}</label>
+              <input value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+            </div>
+            <div className="form-group form-group--checkbox">
+              <label>
+                <input type="checkbox" checked={form.enabled} onChange={(e) => setForm({ ...form, enabled: e.target.checked })} />
+                {t('servers.enabled')}
+              </label>
+            </div>
+
+            <p className="form-section-label">{t('servers.thresholdsTitle')}</p>
+            <p className="form-hint">{t('servers.thresholdsHint')}</p>
+            <div className="form-row">
+              <div className="form-group">
+                <label>{t('servers.diskWarn')}</label>
+                <input type="number" min={0} max={100} value={form.disk_warn_pct} onChange={(e) => setForm({ ...form, disk_warn_pct: e.target.value })} />
+              </div>
+              <div className="form-group">
+                <label>{t('servers.diskCrit')}</label>
+                <input type="number" min={0} max={100} value={form.disk_crit_pct} onChange={(e) => setForm({ ...form, disk_crit_pct: e.target.value })} />
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>{t('servers.cpuWarn')}</label>
+                <input type="number" min={0} max={100} value={form.cpu_warn_pct} onChange={(e) => setForm({ ...form, cpu_warn_pct: e.target.value })} />
+              </div>
+              <div className="form-group">
+                <label>{t('servers.memWarn')}</label>
+                <input type="number" min={0} max={100} value={form.mem_warn_pct} onChange={(e) => setForm({ ...form, mem_warn_pct: e.target.value })} />
+              </div>
+            </div>
+
+            <div className="modal-footer">
+              <button type="button" className="btn" onClick={closeModal}>{t('common.cancel')}</button>
+              <button type="submit" className="btn btn-primary" disabled={saving}>
+                {saving ? t('common.loading') : t('common.save')}
+              </button>
+            </div>
+          </form>
+        </ResourceModal>
+      )}
+    </div>
+  );
+}
+
+export default Servers;

--- a/unibridge-ui/src/pages/alerts/AlertDeliveryPanel.tsx
+++ b/unibridge-ui/src/pages/alerts/AlertDeliveryPanel.tsx
@@ -25,7 +25,21 @@ const defaultSettings: AlertSettings = {
   route_error_threshold_pct: 10,
   check_interval_seconds: 60,
   trigger_after_failures: 2,
+  server_disk_warn_pct: 80,
+  server_disk_crit_pct: 90,
+  server_cpu_warn_pct: 90,
+  server_mem_warn_pct: 90,
+  server_disk_forecast_hours: 24,
+  repeat_alert_after_cycles: 0,
 };
+
+type ServerSettingKey =
+  | 'server_disk_warn_pct'
+  | 'server_disk_crit_pct'
+  | 'server_cpu_warn_pct'
+  | 'server_mem_warn_pct'
+  | 'server_disk_forecast_hours'
+  | 'repeat_alert_after_cycles';
 
 const emptyChannelForm = (): AlertChannelCreate & { headerPairs: HeaderPair[] } => ({
   name: '',
@@ -206,6 +220,12 @@ export default function AlertDeliveryPanel() {
       route_error_threshold_pct: settingsForm.route_error_threshold_pct,
       check_interval_seconds: settingsForm.check_interval_seconds,
       trigger_after_failures: settingsForm.trigger_after_failures,
+      server_disk_warn_pct: settingsForm.server_disk_warn_pct,
+      server_disk_crit_pct: settingsForm.server_disk_crit_pct,
+      server_cpu_warn_pct: settingsForm.server_cpu_warn_pct,
+      server_mem_warn_pct: settingsForm.server_mem_warn_pct,
+      server_disk_forecast_hours: settingsForm.server_disk_forecast_hours,
+      repeat_alert_after_cycles: settingsForm.repeat_alert_after_cycles,
     });
   }
 
@@ -297,6 +317,34 @@ export default function AlertDeliveryPanel() {
             <p className="form-hint">{t('alerts.triggerAfterFailuresHelp')}</p>
           </div>
         </div>
+
+        <p className="form-section-label">{t('alerts.serverThresholdsTitle')}</p>
+        <div className="settings-grid">
+          {([
+            ['server_disk_warn_pct', 'alerts.serverDiskWarn', 0, 100],
+            ['server_disk_crit_pct', 'alerts.serverDiskCrit', 0, 100],
+            ['server_cpu_warn_pct', 'alerts.serverCpuWarn', 0, 100],
+            ['server_mem_warn_pct', 'alerts.serverMemWarn', 0, 100],
+            ['server_disk_forecast_hours', 'alerts.serverForecastHours', 0, 720],
+            ['repeat_alert_after_cycles', 'alerts.repeatAfterCycles', 0, 1000],
+          ] as Array<[ServerSettingKey, string, number, number]>).map(([field, labelKey, min, max]) => (
+            <div className="form-group" key={field}>
+              <label htmlFor={`s-${field}`}>{t(labelKey)}</label>
+              <input
+                id={`s-${field}`}
+                type="number"
+                min={min}
+                max={max}
+                value={settingsForm[field] as number}
+                disabled={!hasSettings || !canWrite}
+                onChange={(e) =>
+                  setSettingsDraft((prev) => ({ ...prev, [field]: Number(e.target.value) }))
+                }
+              />
+            </div>
+          ))}
+        </div>
+
         {canWrite && (
           <button type="submit" className="btn btn-primary" disabled={!hasSettings || updateSettingsMutation.isPending}>
             {updateSettingsMutation.isPending ? t('common.saving') : t('alerts.saveSettings')}


### PR DESCRIPTION
## Summary

Monitor arbitrary Linux servers (the machines APIs run on, or any host we operate) for **reachability, disk, CPU, and memory**, with **proactive alerts** routed through the *existing* alert pipeline — per-resource 담당자 + global 관리자, webhook/mail channel, alert history, and the Alert Status UI. No new alerting infra (no Alertmanager): collection is standard Prometheus + node_exporter; evaluation + delivery reuse UniBridge's alert checker and `dispatch_alert`.

```
[server] node_exporter:9100 ─┐
[server] node_exporter:9100 ─┤→ Prometheus scrape (job "nodes") ─→ alert_checker (instant_query)
[server] node_exporter:9100 ─┘        file_sd from registry            → AlertStateManager → dispatch_alert
```

Delivered in four phases (all in this PR):

### Phase 1 — registry + checks
- `MonitoredHost` registry (migration `0014`) + `/admin/servers` CRUD with `servers.read`/`servers.write` RBAC + audit logging.
- Prometheus `file_sd` `nodes` job written from the registry into a shared volume — add/remove hosts with no Prometheus reload.
- `alert_checker._check_server_health`: `server_down`, `server_disk`, and a **`predict_linear` disk-fill forecast** (`server_disk_forecast`) evaluated via in-app Prometheus queries, fed through the shared state machine + dispatch.
- Lifespan reconciles the targets file on boot and purges stale host alert-state.

### Phase 2 — thresholds + severity
- Per-host nullable threshold overrides (fall back to global `AlertSettings` defaults).
- **warn/critical severity escalation** in `AlertStateManager` (additive & optional — db/nas/upstream/route keep identical binary behaviour), threaded through `dispatch_alert`/`AlertHistory`/`AlertState`.
- CPU + memory signals.

### Phase 3 — UI
- **Servers** registry page + per-host **metrics dashboard** (recharts CPU/mem/disk).
- Severity surfaced in **Alert Status**; global server thresholds editable in **Alert settings**.
- Nav/routes + en/ko i18n (parity checked).

### Phase 4 — ops
- `repeat_alert_after_cycles` re-notification for still-firing alerts.
- `scripts/install_node_exporter.sh` (systemd installer), `docs/server-monitoring.md` (incl. **push mode** for firewalled hosts via remote-write), README/.env updates.

## Decisions
- **In-app evaluation, not Alertmanager** — keeps a single recipient model, audit trail, and UI. Prometheus does collection (what it's best at).
- **Pull by default**; push mode documented for firewalled hosts.
- Host `name` is regex-validated before interpolation into PromQL label selectors / file_sd, blocking injection.

## Testing
- Backend: `ruff` clean, `alembic check` clean, full `pytest` green incl. **19 new tests** (`test_server_monitor.py`, `test_servers_router.py`) covering evaluation, severity escalation, repeat-notify, and CRUD/RBAC.
- Frontend: `tsc -b` build + `eslint` clean + `vitest` 395 tests green.
- Adversarial 5-lens review (correctness/security/migration/frontend/infra) with per-finding verification: 0 confirmed issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)